### PR TITLE
fix: preserve autorefresh state

### DIFF
--- a/app_i-d.py
+++ b/app_i-d.py
@@ -8,6 +8,7 @@ import boto3
 import gspread.utils
 import time
 from zoneinfo import ZoneInfo
+from streamlit_autorefresh import st_autorefresh
 
 TZ = ZoneInfo("America/Mexico_City")
 
@@ -42,7 +43,8 @@ with col_actions:
 # ⏱️ Autorefresco (no limpia caché)
 if st.session_state.get("auto_reload"):
     interval = int(st.session_state.get("auto_reload_interval", 60))
-    st.markdown(f'<meta http-equiv="refresh" content="{interval}">', unsafe_allow_html=True)
+    # Utilizar st_autorefresh evita recargar la página y conserva la sesión
+    st_autorefresh(interval=interval * 1000, key="auto_refresh_counter")
 
 st.markdown("---")
 


### PR DESCRIPTION
## Summary
- use `st_autorefresh` to rerun without reloading the page
- keep autorefresh checkbox state across refreshes

## Testing
- `python -m py_compile app_i-d.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4c85c890c8326b105e54f58a767c1