### PR TITLE
fix: toggle fecha y turno controls to prevent js import failure

### DIFF
--- a/app_a-d.py
+++ b/app_a-d.py
@@ -664,79 +664,119 @@ def mostrar_pedido(df, idx, row, orden, origen_tab, current_main_tab_label, work
 
         # --- Cambiar Fecha y Turno ---
         if row['Estado'] != "🟢 Completado" and row.get("Tipo_Envio") in ["📍 Pedido Local", "🚚 Pedido Foráneo"]:
-            st.session_state["expanded_pedidos"][row['ID_Pedido']] = True
-            st.markdown("##### 📅 Cambiar Fecha y Turno")
-            col_current_info_date, col_current_info_turno, col_inputs = st.columns([1, 1, 2])
-
-            fecha_actual_str = row.get("Fecha_Entrega", "")
-            fecha_actual_dt = pd.to_datetime(fecha_actual_str, errors='coerce') if fecha_actual_str else None
-            fecha_mostrar = fecha_actual_dt.strftime('%d/%m/%Y') if pd.notna(fecha_actual_dt) else "Sin fecha"
-            col_current_info_date.info(f"**Fecha actual:** {fecha_mostrar}")
-
-            current_turno = row.get("Turno", "")
-            if row.get("Tipo_Envio") == "📍 Pedido Local":
-                col_current_info_turno.info(f"**Turno actual:** {current_turno}")
-            else:
-                col_current_info_turno.empty()
-
-            today = datetime.now().date()
-            default_fecha = fecha_actual_dt.date() if pd.notna(fecha_actual_dt) and fecha_actual_dt.date() >= today else today
-
-            fecha_key = f"new_fecha_{row['ID_Pedido']}"
-            turno_key = f"new_turno_{row['ID_Pedido']}"
-
-            if fecha_key not in st.session_state:
-                st.session_state[fecha_key] = default_fecha
-            if turno_key not in st.session_state:
-                st.session_state[turno_key] = current_turno
-
-            st.date_input(
-                "Nueva fecha:",
-                value=st.session_state[fecha_key],
-                min_value=today,
-                max_value=today + timedelta(days=365),
-                format="DD/MM/YYYY",
-                key=fecha_key,
+            # Muestra los controles solo cuando el usuario lo solicite para evitar
+            # renderizar innecesariamente muchos widgets (que pueden provocar el
+            # error "Failed to fetch dynamically imported module").
+            mostrar_cambio = st.checkbox(
+                "📅 Cambiar Fecha y Turno",
+                key=f"chk_fecha_{row['ID_Pedido']}",
             )
 
-            if row.get("Tipo_Envio") == "📍 Pedido Local" and origen_tab in ["Mañana", "Tarde"]:
-                turno_options = ["", "☀️ Local Mañana", "🌙 Local Tarde"]
-                if st.session_state[turno_key] not in turno_options:
-                    st.session_state[turno_key] = turno_options[0]
+            if mostrar_cambio:
+                col_current_info_date, col_current_info_turno, _ = st.columns([1, 1, 2])
 
-                st.selectbox(
-                    "Clasificar turno como:",
-                    options=turno_options,
-                    key=turno_key,
+                fecha_actual_str = row.get("Fecha_Entrega", "")
+                fecha_actual_dt = (
+                    pd.to_datetime(fecha_actual_str, errors='coerce') if fecha_actual_str else None
+                )
+                fecha_mostrar = (
+                    fecha_actual_dt.strftime('%d/%m/%Y')
+                    if pd.notna(fecha_actual_dt)
+                    else "Sin fecha"
+                )
+                col_current_info_date.info(f"**Fecha actual:** {fecha_mostrar}")
+
+                current_turno = row.get("Turno", "")
+                if row.get("Tipo_Envio") == "📍 Pedido Local":
+                    col_current_info_turno.info(f"**Turno actual:** {current_turno}")
+                else:
+                    col_current_info_turno.empty()
+
+                today = datetime.now().date()
+                default_fecha = (
+                    fecha_actual_dt.date()
+                    if pd.notna(fecha_actual_dt) and fecha_actual_dt.date() >= today
+                    else today
                 )
 
-            if st.button("✅ Aplicar Cambios de Fecha/Turno", key=f"btn_apply_{row['ID_Pedido']}"):
-                st.session_state["expanded_pedidos"][row['ID_Pedido']] = True
-                cambios = []
-                nueva_fecha_str = st.session_state[fecha_key].strftime('%Y-%m-%d')
+                fecha_key = f"new_fecha_{row['ID_Pedido']}"
+                turno_key = f"new_turno_{row['ID_Pedido']}"
 
-                if nueva_fecha_str != fecha_actual_str:
-                    col_idx = headers.index("Fecha_Entrega") + 1
-                    cambios.append({'range': gspread.utils.rowcol_to_a1(gsheet_row_index, col_idx), 'values': [[nueva_fecha_str]]})
+                if fecha_key not in st.session_state:
+                    st.session_state[fecha_key] = default_fecha
+                if turno_key not in st.session_state:
+                    st.session_state[turno_key] = current_turno
+
+                st.date_input(
+                    "Nueva fecha:",
+                    value=st.session_state[fecha_key],
+                    min_value=today,
+                    max_value=today + timedelta(days=365),
+                    format="DD/MM/YYYY",
+                    key=fecha_key,
+                )
 
                 if row.get("Tipo_Envio") == "📍 Pedido Local" and origen_tab in ["Mañana", "Tarde"]:
-                    nuevo_turno = st.session_state[turno_key]
-                    if nuevo_turno != current_turno:
-                        col_idx = headers.index("Turno") + 1
-                        cambios.append({'range': gspread.utils.rowcol_to_a1(gsheet_row_index, col_idx), 'values': [[nuevo_turno]]})
+                    turno_options = ["", "☀️ Local Mañana", "🌙 Local Tarde"]
+                    if st.session_state[turno_key] not in turno_options:
+                        st.session_state[turno_key] = turno_options[0]
 
-                if cambios:
-                    if batch_update_gsheet_cells(worksheet, cambios):
-                        if "Fecha_Entrega" in headers:
-                            df.at[idx, "Fecha_Entrega"] = nueva_fecha_str
-                        if "Turno" in headers and row.get("Tipo_Envio") == "📍 Pedido Local":
-                            df.at[idx, "Turno"] = st.session_state[turno_key]
+                    st.selectbox(
+                        "Clasificar turno como:",
+                        options=turno_options,
+                        key=turno_key,
+                    )
 
-                        st.toast(f"📅 Pedido {row['ID_Pedido']} actualizado.", icon="✅")
+                if st.button(
+                    "✅ Aplicar Cambios de Fecha/Turno",
+                    key=f"btn_apply_{row['ID_Pedido']}",
+                ):
+                    st.session_state["expanded_pedidos"][row['ID_Pedido']] = True
+                    cambios = []
+                    nueva_fecha_str = st.session_state[fecha_key].strftime('%Y-%m-%d')
+
+                    if nueva_fecha_str != fecha_actual_str:
+                        col_idx = headers.index("Fecha_Entrega") + 1
+                        cambios.append(
+                            {
+                                'range': gspread.utils.rowcol_to_a1(
+                                    gsheet_row_index, col_idx
+                                ),
+                                'values': [[nueva_fecha_str]],
+                            }
+                        )
+
+                    if row.get("Tipo_Envio") == "📍 Pedido Local" and origen_tab in ["Mañana", "Tarde"]:
+                        nuevo_turno = st.session_state[turno_key]
+                        if nuevo_turno != current_turno:
+                            col_idx = headers.index("Turno") + 1
+                            cambios.append(
+                                {
+                                    'range': gspread.utils.rowcol_to_a1(
+                                        gsheet_row_index, col_idx
+                                    ),
+                                    'values': [[nuevo_turno]],
+                                }
+                            )
+
+                    if cambios:
+                        if batch_update_gsheet_cells(worksheet, cambios):
+                            if "Fecha_Entrega" in headers:
+                                df.at[idx, "Fecha_Entrega"] = nueva_fecha_str
+                            if (
+                                "Turno" in headers
+                                and row.get("Tipo_Envio") == "📍 Pedido Local"
+                            ):
+                                df.at[idx, "Turno"] = st.session_state[turno_key]
+
+                            st.toast(
+                                f"📅 Pedido {row['ID_Pedido']} actualizado.",
+                                icon="✅",
+                            )
+                        else:
+                            st.error("❌ Falló la actualización en Google Sheets.")
                     else:
-                        st.error("❌ Falló la actualización en Google Sheets.")
-                else:
-                    st.info("No hubo cambios para aplicar.")
+                        st.info("No hubo cambios para aplicar.")
 
 
         


### PR DESCRIPTION
## Summary
- Show date/shift change inputs only when the user requests them to avoid excessive widget rendering that caused JS module import errors.

## Testing
- `python -m py_compile app_a-d.py`
- `python -m py_compile app_i-d.py app_gerente.py`


------
https://chatgpt.com/codex/tasks/task_e_68a83df44468832698bec845c15564cc