### PR TITLE
fix: remove unsupported S3 ACL

### DIFF
--- a/app_a-d.py
+++ b/app_a-d.py
@@ -436,7 +436,6 @@ def upload_file_to_s3(s3_client_param, bucket_name, file_obj, s3_key):
             Bucket=bucket_name,
             Key=s3_key,
             Body=file_obj.getvalue(),
-            ACL="public-read",  # 👈 hace el objeto público
             **extra_args
         )
 
@@ -536,7 +535,7 @@ def get_files_in_s3_prefix(s3_client_param, prefix):
 
 def get_s3_file_download_url(s3_client_param, object_key):
     """
-    Retorna una URL pública permanente para archivos subidos con ACL='public-read'.
+    Retorna una URL pública permanente para archivos almacenados en S3.
     """
     return f"https://{S3_BUCKET_NAME}.s3.{AWS_REGION}.amazonaws.com/{object_key}"
 


### PR DESCRIPTION
## Summary
- prevent S3 ACL errors by removing unsupported ACL parameter
- clarify S3 download URL helper

## Testing
- `python -m py_compile app_a-d.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac83b2832c832686a3cdc5a76d4002