### PR TITLE
Fix filtering for completed special cases

### DIFF
--- a/app_i-d.py
+++ b/app_i-d.py
@@ -797,10 +797,19 @@ with tabs[2]:
         if casos.empty:
             st.info("No hay devoluciones/garantías para mostrar.")
         else:
-            # Excluir Completados de la vista
+            # Excluir completados limpiados, mostrar el resto
+            if "Completados_Limpiado" not in casos.columns:
+                casos["Completados_Limpiado"] = ""
             if "Estado" in casos.columns:
                 casos = casos[
-                    casos["Estado"].astype(str).str.strip() != "🟢 Completado"
+                    (casos["Estado"].astype(str).str.strip() != "🟢 Completado")
+                    | (
+                        (casos["Estado"].astype(str).str.strip() == "🟢 Completado")
+                        & (
+                            casos["Completados_Limpiado"].astype(str).str.lower()
+                            != "sí"
+                        )
+                    )
                 ]
 
             # Asegura columnas base


### PR DESCRIPTION
## Summary
- show special cases marked as completed unless explicitly cleaned

## Testing
- `python -m py_compile app_i-d.py`

------
https://chatgpt.com/codex/tasks/task_e_68ac9ce1781883269a79bfdc7c795012