### PR TITLE
Retry Google Sheets access on API errors

### DIFF
--- a/app_a-d.py
+++ b/app_a-d.py
@@ -1417,7 +1417,14 @@ if not df_main.empty:
     df_pendientes_proceso_demorado = df_main[df_main["Estado"].isin(["🟡 Pendiente", "🔵 En Proceso", "🔴 Demorado", "🛠 Modificación"])].copy()
 
     # === CASOS ESPECIALES (Devoluciones/Garantías) ===
-    worksheet_casos = g_spread_client.open_by_key(GOOGLE_SHEET_ID).worksheet("casos_especiales")
+    try:
+        worksheet_casos = g_spread_client.open_by_key(GOOGLE_SHEET_ID).worksheet("casos_especiales")
+    except gspread.exceptions.APIError as e:
+        st.error(f"❌ Error al abrir 'casos_especiales': {e}")
+        st.cache_resource.clear()
+        time.sleep(1)
+        g_spread_client = get_gspread_client(_credentials_json_dict=GSHEETS_CREDENTIALS)
+        worksheet_casos = g_spread_client.open_by_key(GOOGLE_SHEET_ID).worksheet("casos_especiales")
 
     # Asegurar físicamente en la hoja las columnas que vamos a escribir (si faltan, se agregan)
     required_cols_casos = [


### PR DESCRIPTION
## Summary
- Handle gspread API errors when opening `casos_especiales`
- Clear cache and refresh credentials before retrying

## Testing
- `python -m py_compile app_a-d.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7b29ea0808326974725e1b2890402