### PR TITLE
Make uploaded S3 files public and return permanent URLs

### DIFF
--- a/app_a-d.py
+++ b/app_a-d.py
@@ -441,7 +441,8 @@ def upload_file_to_s3(s3_client_param, bucket_name, file_obj, s3_key):
             Bucket=bucket_name,
             Key=s3_key,
             Body=file_obj.getvalue(),
-            **extra_args
+            ACL="public-read",
+            **extra_args,
         )
 
         url = f"https://{bucket_name}.s3.{AWS_REGION}.amazonaws.com/{s3_key}"


### PR DESCRIPTION
## Summary
- Add `public-read` ACL when uploading files to S3 so objects are accessible
- Return permanent S3 URL from `upload_file_to_s3`

## Testing
- `python -m py_compile app_a-d.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9044287a88326a3f78d450df6b4af