### PR TITLE
Show seguimiento info for warranties

### DIFF
--- a/app_a-d.py
+++ b/app_a-d.py
@@ -2426,6 +2426,7 @@ with main_tabs[6]:  # 🛠 Garantías
             st.info(str(row.get("Material_Devuelto", "")).strip() or "N/A")
 
             monto_txt = str(row.get("Monto_Devuelto", "")).strip()
+            seguimiento_txt = str(row.get("Seguimiento", "")).strip()
             if monto_txt:
                 st.markdown(f"**💵 Monto estimado (si aplica):** {monto_txt}")
 
@@ -2434,6 +2435,10 @@ with main_tabs[6]:  # 🛠 Garantías
             if coment_admin:
                 st.markdown("**📝 Comentario Administrativo:**")
                 st.info(coment_admin)
+
+            if seguimiento_txt:
+                st.markdown("**📌 Seguimiento:**")
+                st.info(seguimiento_txt)
 
             # === Clasificar envío/turno/fecha (igual que devoluciones) ===
             st.markdown("---")
@@ -2945,8 +2950,19 @@ with main_tabs[7]:  # ✅ Historial Completados
                     st.markdown("📦 Piezas afectadas:")
                     st.info(piezas)
                 monto = str(row.get("Monto_Devuelto", "")).strip()
+                seguimiento_txt = str(row.get("Seguimiento", "")).strip()
                 if monto:
                     st.markdown(f"💵 Monto estimado: {monto}")
+
+                coment_admin = str(row.get("Comentarios_Admin_Garantia", "")).strip() or str(row.get("Comentarios_Admin_Devolucion", "")).strip()
+                if coment_admin:
+                    st.markdown("**📝 Comentario Administrativo:**")
+                    st.info(coment_admin)
+
+                if seguimiento_txt:
+                    st.markdown("**📌 Seguimiento:**")
+                    st.info(seguimiento_txt)
+
                 adjuntos = _normalize_urls(row.get("Adjuntos", ""))
                 guia = str(row.get("Hoja_Ruta_Mensajero", "")).strip()
                 with st.expander("📎 Archivos del Caso", expanded=False):


### PR DESCRIPTION
## Summary
- Add seguimiento field and display for warranty items
- Include administrative comments and seguimiento in historical warranty view

## Testing
- `python -m py_compile app_a-d.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9047200b88326a545fc5b678d8e96