### PR TITLE
Render seguimiento y comentario siempre

### DIFF
--- a/app_a-d.py
+++ b/app_a-d.py
@@ -1840,14 +1840,17 @@ with main_tabs[5]:
                 st.markdown(f"📂 Documento Adicional: {doc_extra}")
 
         seguimiento = str(row.get("Seguimiento", "")).strip()
+        comentario = str(row.get("Comentario", "")).strip()
         coment_admin = str(row.get("Comentarios_Admin_Devolucion", "")).strip()
         if coment_admin:
             st.markdown("🗒️ Comentario Administrativo:")
             st.info(coment_admin)
 
-        if seguimiento:
-            st.markdown("📌 Seguimiento:")
-            st.info(seguimiento)
+        st.markdown("📌 Seguimiento:")
+        st.info(seguimiento or "")
+
+        st.markdown("📝 Comentario:")
+        st.info(comentario or "")
 
         mod_surtido = str(row.get("Modificacion_Surtido", "")).strip()
         adj_surtido = _normalize_urls(row.get("Adjuntos_Surtido", ""))


### PR DESCRIPTION
## Summary
- Siempre mostrar etiquetas de seguimiento y comentario en devolución especial

## Testing
- `python -m py_compile app_a-d.py`
- `python - <<'PY'
import pathlib, textwrap
from urllib.parse import urlparse, unquote
text=pathlib.Path('app_a-d.py').read_text().splitlines()
func_lines=text[1764:1869]
func_code=textwrap.dedent('\n'.join(func_lines))
class Stub:
    def markdown(self, x):
        print('markdown:', x)
    def info(self, x):
        print('info:', x)
st=Stub()
namespace={'st':st,'_normalize_urls':lambda x:[], 'os':__import__('os'), 'urlparse':urlparse, 'unquote':unquote}
exec(func_code, namespace)
row={}
namespace['render_caso_especial_devolucion'](row)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b90c5697c08326a299d50fc1cc4091