### PR TITLE
Make special cases filter optional in manager app

### DIFF
--- a/app_gerente.py
+++ b/app_gerente.py
@@ -600,7 +600,11 @@ with tabs[1]:
                 return True
         return False
 
-    df_casos = df_casos[df_casos.apply(es_devol_o_garant, axis=1)]
+    filtrar_devoluciones = st.checkbox(
+        "Mostrar solo devoluciones o garantías", value=False
+    )
+    if filtrar_devoluciones:
+        df_casos = df_casos[df_casos.apply(es_devol_o_garant, axis=1)]
 
     for d in (df_pedidos, df_casos):
         d["Hora_Registro"] = pd.to_datetime(d["Hora_Registro"], errors="coerce")


### PR DESCRIPTION
## Summary
- allow toggling filter for devoluciones/garantías in modification tab
- include all `casos_especiales` by default when searching by name

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app_gerente.py`
- `streamlit run app_gerente.py --server.headless true --server.port 8501`

------
https://chatgpt.com/codex/tasks/task_e_68b9c9faa2f48326af8903917d0751bf