### PR TITLE
Preserve scroll position after printing orders

### DIFF
--- a/app_a-d.py
+++ b/app_a-d.py
@@ -757,7 +757,7 @@ def mostrar_pedido_detalle(
             "active_date_tab_t_index", 0
         )
 
-        st.cache_data.clear()
+        st.session_state["scroll_to_pedido_id"] = row["ID_Pedido"]
         st.session_state["print_clicked"] = row["ID_Pedido"]
 
 def mostrar_pedido(df, idx, row, orden, origen_tab, current_main_tab_label, worksheet, headers, s3_client_param,


### PR DESCRIPTION
## Summary
- Avoid clearing cached data after print to prevent unnecessary reloads
- Store `scroll_to_pedido_id` so UI recenters on the printed order while keeping expanders and attachments open

## Testing
- `python -m py_compile app_a-d.py`
- `streamlit run app_a-d.py --server.headless true` *(fails to fully verify UI behavior due to headless environment)*

------
https://chatgpt.com/codex/tasks/task_e_68bc8b890dd0832695b4192cf5929bfa