### PR TITLE
Mantener pestañas y expansor al subir guía

### DIFF
--- a/app_a-d.py
+++ b/app_a-d.py
@@ -696,6 +696,14 @@ def handle_generic_upload_change():
     # así que evitamos una llamada explícita a st.rerun().
 
 
+def handle_guia_upload_change(row):
+    """Mantiene expansores y pestañas al seleccionar archivos de guía."""
+    st.session_state["expanded_pedidos"][row["ID_Pedido"]] = True
+    st.session_state["expanded_subir_guia"][row["ID_Pedido"]] = True
+    st.session_state["scroll_to_pedido_id"] = row["ID_Pedido"]
+    preserve_tab_state()
+
+
 def mostrar_pedido_detalle(
     df,
     idx,
@@ -1086,6 +1094,8 @@ def mostrar_pedido(df, idx, row, orden, origen_tab, current_main_tab_label, work
                     type=["pdf", "jpg", "jpeg", "png"],
                     accept_multiple_files=True,
                     key=upload_key,
+                    on_change=handle_guia_upload_change,
+                    args=(row,),
                 )
 
                 if st.button(


### PR DESCRIPTION
## Summary
- Mantén expandido el pedido y la sección de subir guía al adjuntar archivos
- Conserva la pestaña activa y posición del pedido durante el rerun

## Testing
- `python -m py_compile app_a-d.py`


------
https://chatgpt.com/codex/tasks/task_e_68be35db64cc8326a143978fb7919eab