### PR TITLE
Ensure S3 links in guarantee case renderer are signed

### DIFF
--- a/app_a-d.py
+++ b/app_a-d.py
@@ -3177,8 +3177,9 @@ with main_tabs[7]:  # ✅ Historial Completados
                         for u in adjuntos:
                             nombre = os.path.basename(urlparse(u).path) or u
                             nombre = unquote(nombre)
+                            url = get_s3_file_download_url(s3_client, u)
                             st.markdown(
-                                f'- <a href="{u}" target="_blank">{nombre}</a>',
+                                f'- <a href="{url}" target="_blank">{nombre}</a>',
                                 unsafe_allow_html=True,
                             )
                     if guias:


### PR DESCRIPTION
## Summary
- Generate signed S3 download URLs for attachments in `render_caso_especial_garantia_hist`
- Keep guarantee case renderers free of raw hyperlinks

## Testing
- `python -m py_compile app_a-d.py`
- `rg -F '<a href="{u}"' -n app_a-d.py`


------
https://chatgpt.com/codex/tasks/task_e_68bfa14f19848326a90ca9e60f8b8a81