### PR TITLE
Mark cleaned orders as shipped

### DIFF
--- a/app_a-d.py
+++ b/app_a-d.py
@@ -3060,7 +3060,7 @@ with main_tabs[7]:  # ✅ Historial Completados/Cancelados
                     if row.get("Estado") == "🟢 Completado":
                         updates.append({
                             'range': gspread.utils.rowcol_to_a1(g_row, estado_col_idx),
-                            'values': [["Viajó"]]
+                            'values': [["✅ Viajó"]]
                         })
             if updates and batch_update_gsheet_cells(worksheet_main, updates):
                 st.success(f"✅ {len(updates)} pedidos marcados como limpiados.")
@@ -3105,7 +3105,7 @@ with main_tabs[7]:  # ✅ Historial Completados/Cancelados
                         if row.get("Estado") == "🟢 Completado":
                             updates.append({
                                 'range': gspread.utils.rowcol_to_a1(g_row, estado_col_idx),
-                                'values': [["Viajó"]]
+                                'values': [["✅ Viajó"]]
                             })
                     if updates and batch_update_gsheet_cells(worksheet_main, updates):
                         st.success(f"✅ {len(updates)} pedidos en {grupo} marcados como limpiados.")
@@ -3135,7 +3135,7 @@ with main_tabs[7]:  # ✅ Historial Completados/Cancelados
                     if row.get("Estado") == "🟢 Completado":
                         updates.append({
                             'range': gspread.utils.rowcol_to_a1(g_row, estado_col_idx),
-                            'values': [["Viajó"]]
+                            'values': [["✅ Viajó"]]
                         })
                 if updates and batch_update_gsheet_cells(worksheet_main, updates):
                     st.success(f"✅ {len(updates)} pedidos foráneos completados/cancelados fueron marcados como limpiados.")
@@ -3239,7 +3239,7 @@ with main_tabs[7]:  # ✅ Historial Completados/Cancelados
                         if row.get("Estado") == "🟢 Completado":
                             updates.append({
                                 'range': gspread.utils.rowcol_to_a1(g_row, estado_col_idx),
-                                'values': [["Viajó"]]
+                                'values': [["✅ Viajó"]]
                             })
                     if updates and batch_update_gsheet_cells(worksheet_casos, updates):
                         st.success(f"✅ {len(updates)} devoluciones marcadas como limpiadas.")
@@ -3268,7 +3268,7 @@ with main_tabs[7]:  # ✅ Historial Completados/Cancelados
                         if row.get("Estado") == "🟢 Completado":
                             updates.append({
                                 'range': gspread.utils.rowcol_to_a1(g_row, estado_col_idx),
-                                'values': [["Viajó"]]
+                                'values': [["✅ Viajó"]]
                             })
                     if updates and batch_update_gsheet_cells(worksheet_casos, updates):
                         st.success(f"✅ {len(updates)} garantías marcadas como limpiadas.")


### PR DESCRIPTION
## Summary
- Ensure cleaning actions mark `Completados_Limpiado` and update `Estado` to `✅ Viajó` for completed items

## Testing
- `python -m py_compile app_a-d.py`


------
https://chatgpt.com/codex/tasks/task_e_68c19118ba288326bfd6f4eaaadad9cf