### PR TITLE
refactor: remove duplicate datetime and timezone imports

### DIFF
--- a/app_a-d.py
+++ b/app_a-d.py
@@ -15,9 +15,6 @@ from pytz import timezone
 from urllib.parse import urlparse, unquote
 import streamlit.components.v1 as components
 
-from datetime import datetime
-from pytz import timezone
-
 _MX_TZ = timezone("America/Mexico_City")
 
 def mx_now():
@@ -1895,7 +1892,6 @@ with main_tabs[5]:
     import json
     import math
     import re
-    from datetime import datetime, timedelta
     try:
         from zoneinfo import ZoneInfo
         _TZ = ZoneInfo("America/Mexico_City")
@@ -2645,7 +2641,6 @@ with main_tabs[6]:  # 🛠 Garantías
 
     import os, json, math, re
     import pandas as pd
-    from datetime import datetime, timedelta
     try:
         from zoneinfo import ZoneInfo
         _TZ = ZoneInfo("America/Mexico_City")


### PR DESCRIPTION
## Summary
- consolidate datetime and timezone imports at top of app_a-d.py
- remove redundant per-function datetime imports

## Testing
- `python -m py_compile app_a-d.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2e486287483269667273bda4e69e4