### PR TITLE
feat: add state and shipping filters

### DIFF
--- a/app_gerente.py
+++ b/app_gerente.py
@@ -687,6 +687,8 @@ with tabs[1]:
                 "Rango de tiempo",
                 ["12 horas", "24 horas", "7 días", "Todos"],
             )
+        estados_sel = st.multiselect("Estado", sorted(df["Estado"].dropna().unique()))
+        tipos_sel = st.multiselect("Tipo de envío", sorted(df["Tipo_Envio"].dropna().unique()))
 
         filtrado = df
         delta = None
@@ -701,6 +703,10 @@ with tabs[1]:
             filtrado = filtrado[filtrado["Hora_Registro"] >= datetime.now() - delta]
         if vendedores_sel:
             filtrado = filtrado[filtrado["Vendedor_Registro"].isin(vendedores_sel)]
+        if estados_sel:
+            filtrado = filtrado[filtrado["Estado"].isin(estados_sel)]
+        if tipos_sel:
+            filtrado = filtrado[filtrado["Tipo_Envio"].isin(tipos_sel)]
 
         st.markdown(f"{len(filtrado)} registros encontrados")
         st.dataframe(filtrado.head(100))


### PR DESCRIPTION
## Summary
- add multiselect filters for Estado and Tipo de envío to descarga tab
- include Estado and Tipo_Envio in dataframe filtering before export

## Testing
- `python -m py_compile app_gerente.py`


------
https://chatgpt.com/codex/tasks/task_e_68c33712e3cc8326b45db29b822f881e