### PR TITLE
Show all filtered rows in gerente app

### DIFF
--- a/app_gerente.py
+++ b/app_gerente.py
@@ -695,7 +695,8 @@ with tabs[1]:
             filtrado = filtrado[filtrado["Tipo_Envio"].isin(tipos_sel)]
 
         st.markdown(f"{len(filtrado)} registros encontrados")
-        st.dataframe(filtrado.head(100))
+        # Show all rows that match the selected filters without truncating
+        st.dataframe(filtrado)
 
         buffer = BytesIO()
         with pd.ExcelWriter(buffer, engine="xlsxwriter") as writer:


### PR DESCRIPTION
## Summary
- display the entire filtered table in the gerente dashboard instead of truncating to 100 rows

## Testing
- `python -m py_compile app_gerente.py`
- `python - <<'PY'\nimport pandas as pd\nfrom datetime import datetime, timedelta\nnow = datetime.now()\nhoras = pd.date_range(end=now, periods=200, freq='H')\ndf = pd.DataFrame({'Hora_Registro': horas, 'Estado':['A']*200, 'Tipo_Envio':['T']*200})\nfiltrado = df.copy()\nprint('Todos:', len(filtrado))\ndelta = timedelta(hours=24)\nfiltrado_24 = filtrado[filtrado['Hora_Registro'] >= now - delta]\nprint('24 horas:', len(filtrado_24))\nPY`

------
https://chatgpt.com/codex/tasks/task_e_68c4333d09348326a349049cd6d3d4b1