### PR TITLE
Limpia ID_Pedido y reindexa tabla de descargas

### DIFF
--- a/app_gerente.py
+++ b/app_gerente.py
@@ -696,6 +696,10 @@ with tabs[1]:
         if tipos_sel:
             filtrado = filtrado[filtrado["Tipo_Envio"].isin(tipos_sel)]
 
+        filtrado = filtrado.drop(columns=["ID_Pedido"], errors="ignore")
+        filtrado = filtrado.reset_index(drop=True)
+        filtrado.index = filtrado.index + 1
+
         st.markdown(f"{len(filtrado)} registros encontrados")
         # Show all rows that match the selected filters without truncating
         st.dataframe(filtrado)


### PR DESCRIPTION
## Summary
- Elimina `ID_Pedido` de la tabla filtrada para descargas y reinicia el índice comenzando en 1.
- Exporta a Excel el mismo DataFrame mostrado, sin la columna eliminada.

## Testing
- `python -m py_compile app_gerente.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4408239308326b2a6ac0852c66b5d