### PR TITLE
Normaliza ID_Pedido y aplica filtro numérico en app_gerente

### DIFF
--- a/app_gerente.py
+++ b/app_gerente.py
@@ -740,6 +740,10 @@ with tabs[2]:
     df_pedidos = cargar_pedidos()
     df_casos = cargar_casos_especiales()
 
+    for d in (df_pedidos, df_casos):
+        d["ID_Pedido"] = pd.to_numeric(d["ID_Pedido"], errors="coerce")
+        d["Hora_Registro"] = pd.to_datetime(d["Hora_Registro"], errors="coerce")
+
     def es_devol_o_garant(row):
         for col in ("Tipo_Envio", "Tipo_Caso"):
             valor = str(row.get(col, ""))
@@ -749,14 +753,10 @@ with tabs[2]:
 
     df_casos = df_casos[df_casos.apply(es_devol_o_garant, axis=1)]
 
-    for d in (df_pedidos, df_casos):
-        d["Hora_Registro"] = pd.to_datetime(d["Hora_Registro"], errors="coerce")
-
     df_pedidos["__source"] = "pedidos"
     df_casos["__source"] = "casos"
     df = pd.concat([df_pedidos, df_casos], ignore_index=True, sort=False)
     df = df[df["ID_Pedido"].notna()]
-    df["ID_Pedido"] = pd.to_numeric(df["ID_Pedido"], errors="coerce")
     df = df.sort_values(by="ID_Pedido", ascending=True)
 
     if "pedido_modificado" in st.session_state:
@@ -844,7 +844,7 @@ with tabs[2]:
         st.stop()
 
     row_df = df_pedidos if source_sel == "pedidos" else df_casos
-    filtro = row_df[row_df["ID_Pedido"].astype(str) == str(pedido_sel)]
+    filtro = row_df[pd.to_numeric(row_df["ID_Pedido"], errors="coerce") == float(pedido_sel)]
     if filtro.empty:
         st.warning("No se encontró un pedido con el ID seleccionado.")
         st.stop()


### PR DESCRIPTION
## Summary
- Normaliza `ID_Pedido` y `Hora_Registro` tras cargar datos de pedidos y casos.
- Compara pedidos por ID usando valores numéricos para evitar coincidencias vacías.

## Testing
- `python -m py_compile app_gerente.py`
- `python - <<'PY'
import pandas as pd
row_df = pd.DataFrame({'ID_Pedido':['123','abc','456'], 'info':['a','b','c']})
pedido_sel = 123
filtro = row_df[pd.to_numeric(row_df['ID_Pedido'], errors='coerce') == float(pedido_sel)]
print(filtro)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68c44353c1588326ac9a64526e35f75c