### PR TITLE
Ensure consecutive index in recent orders selection

### DIFF
--- a/app_gerente.py
+++ b/app_gerente.py
@@ -818,6 +818,7 @@ with tabs[2]:
 
     else:
         ultimos_10 = df.head(10).copy()
+        ultimos_10 = ultimos_10.reset_index(drop=True)
         st.markdown("### 🕒 Últimos 10 Pedidos Registrados")
 
         def _format_display(row):
@@ -835,7 +836,7 @@ with tabs[2]:
             ultimos_10.index,
             format_func=lambda i: ultimos_10.loc[i, "display"]
         )
-        pedido_sel = ultimos_10.loc[idx_seleccion, "ID_Pedido"]
+        pedido_sel = ultimos_10.iloc[idx_seleccion]["ID_Pedido"]
         source_sel = ultimos_10.loc[idx_seleccion, "__source"]
 
 


### PR DESCRIPTION
## Summary
- Reset DataFrame index for last 10 orders so selection uses consecutive integers.
- Use iloc to select order ID, preventing KeyError when index isn't found.

## Testing
- `python -m py_compile app_gerente.py`
- `python - <<'PY'
import pandas as pd
rows = list(range(1, 11))
ultimos_10 = pd.DataFrame({'ID_Pedido': rows, '__source': ['s']*10})
ultimos_10 = ultimos_10.head(10).copy()
ultimos_10 = ultimos_10.reset_index(drop=True)
idx_seleccion = 5
pedido_sel = ultimos_10.iloc[idx_seleccion]["ID_Pedido"]
source_sel = ultimos_10.loc[idx_seleccion, "__source"]
print('index range:', list(ultimos_10.index))
print('selected idx:', idx_seleccion)
print('pedido_sel:', pedido_sel)
print('source_sel:', source_sel)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68c44630d0d88326aa864b8eff64957b