### PR TITLE
Validate selection before indexing in manager app

### DIFF
--- a/app_gerente.py
+++ b/app_gerente.py
@@ -836,7 +836,11 @@ with tabs[2]:
             ultimos_10.index,
             format_func=lambda i: ultimos_10.loc[i, "display"]
         )
-        pedido_sel = ultimos_10.iloc[idx_seleccion]["ID_Pedido"]
+        if idx_seleccion is None or idx_seleccion not in ultimos_10.index:
+            st.warning("⚠️ Selección inválida.")
+            st.stop()
+
+        pedido_sel = ultimos_10.loc[idx_seleccion, "ID_Pedido"]
         source_sel = ultimos_10.loc[idx_seleccion, "__source"]
 
 


### PR DESCRIPTION
## Summary
- Safely handle recent order selection by verifying the selected index exists and isn't `None`
- Retrieve `ID_Pedido` and `__source` using label-based `.loc` indexing

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c44783e2e883268d22a7b07d558cf1