### PR TITLE
Trim client name before normalization in modify order tab

### DIFF
--- a/app_gerente.py
+++ b/app_gerente.py
@@ -775,7 +775,7 @@ with tabs[2]:
     if usar_busqueda:
         st.markdown("### 🔍 Buscar Pedido por Cliente")
         cliente_buscado = st.text_input("👤 Escribe el nombre del cliente:")
-        cliente_normalizado = normalizar(cliente_buscado)
+        cliente_normalizado = normalizar(cliente_buscado.strip())
         coincidencias = []
 
         if cliente_buscado:


### PR DESCRIPTION
## Summary
- strip leading/trailing spaces before normalizing client search input in modify-order tab

## Testing
- `pytest`
- `python -m py_compile app_gerente.py`


------
https://chatgpt.com/codex/tasks/task_e_68c4862f94788326ba5c294b50d7d19f