### PR TITLE
Limit fecha/turno editor to one pedido at a time

### DIFF
--- a/app_a-d.py
+++ b/app_a-d.py
@@ -138,6 +138,8 @@ if "prev_casos_count" not in st.session_state:
     st.session_state["prev_casos_count"] = 0
 if "need_compare" not in st.session_state:
     st.session_state["need_compare"] = False
+if "pedido_en_edicion" not in st.session_state:
+    st.session_state["pedido_en_edicion"] = None
 
 # --- Soft reload si el usuario presionó "Recargar Pedidos (seguro)"
 if st.session_state.get("reload_pedidos_soft"):
@@ -934,119 +936,136 @@ def mostrar_pedido(df, idx, row, orden, origen_tab, current_main_tab_label, work
 
         # --- Cambiar Fecha y Turno ---
         if row['Estado'] not in ["🟢 Completado", "✅ Viajó"] and row.get("Tipo_Envio") in ["📍 Pedido Local", "🚚 Pedido Foráneo"]:
-            # Muestra los controles solo cuando el usuario lo solicite para evitar
-            # renderizar innecesariamente muchos widgets (que pueden provocar el
-            # error "Failed to fetch dynamically imported module").
-            mostrar_cambio = st.checkbox(
-                "📅 Cambiar Fecha y Turno",
-                key=f"chk_fecha_{row['ID_Pedido']}",
+            editing_target = st.session_state.get("pedido_en_edicion")
+            fecha_actual_str = row.get("Fecha_Entrega", "")
+            fecha_actual_dt = (
+                pd.to_datetime(fecha_actual_str, errors='coerce') if fecha_actual_str else None
+            )
+            today = datetime.now().date()
+            default_fecha = (
+                fecha_actual_dt.date()
+                if pd.notna(fecha_actual_dt) and fecha_actual_dt.date() >= today
+                else today
             )
 
-            if mostrar_cambio:
-                col_current_info_date, col_current_info_turno, _ = st.columns([1, 1, 2])
+            fecha_key = f"new_fecha_{row['ID_Pedido']}"
+            turno_key = f"new_turno_{row['ID_Pedido']}"
+            current_turno = row.get("Turno", "")
 
-                fecha_actual_str = row.get("Fecha_Entrega", "")
-                fecha_actual_dt = (
-                    pd.to_datetime(fecha_actual_str, errors='coerce') if fecha_actual_str else None
-                )
-                fecha_mostrar = (
-                    fecha_actual_dt.strftime('%d/%m/%Y')
-                    if pd.notna(fecha_actual_dt)
-                    else "Sin fecha"
-                )
-                col_current_info_date.info(f"**Fecha actual:** {fecha_mostrar}")
+            if editing_target == row["ID_Pedido"]:
+                with st.container(border=True):
+                    st.caption("✏️ Editar fecha y turno de entrega")
+                    col_current_info_date, col_current_info_turno, _ = st.columns([1, 1, 2])
 
-                current_turno = row.get("Turno", "")
-                if row.get("Tipo_Envio") == "📍 Pedido Local":
-                    col_current_info_turno.info(f"**Turno actual:** {current_turno}")
-                else:
-                    col_current_info_turno.empty()
+                    fecha_mostrar = (
+                        fecha_actual_dt.strftime('%d/%m/%Y')
+                        if pd.notna(fecha_actual_dt)
+                        else "Sin fecha"
+                    )
+                    col_current_info_date.info(f"**Fecha actual:** {fecha_mostrar}")
 
-                today = datetime.now().date()
-                default_fecha = (
-                    fecha_actual_dt.date()
-                    if pd.notna(fecha_actual_dt) and fecha_actual_dt.date() >= today
-                    else today
-                )
+                    if row.get("Tipo_Envio") == "📍 Pedido Local":
+                        col_current_info_turno.info(f"**Turno actual:** {current_turno}")
+                    else:
+                        col_current_info_turno.empty()
 
-                fecha_key = f"new_fecha_{row['ID_Pedido']}"
-                turno_key = f"new_turno_{row['ID_Pedido']}"
+                    if fecha_key not in st.session_state:
+                        st.session_state[fecha_key] = default_fecha
+                    if turno_key not in st.session_state:
+                        st.session_state[turno_key] = current_turno
 
-                if fecha_key not in st.session_state:
-                    st.session_state[fecha_key] = default_fecha
-                if turno_key not in st.session_state:
-                    st.session_state[turno_key] = current_turno
-
-                st.date_input(
-                    "Nueva fecha:",
-                    value=st.session_state[fecha_key],
-                    min_value=today,
-                    max_value=today + timedelta(days=365),
-                    format="DD/MM/YYYY",
-                    key=fecha_key,
-                )
-
-                if row.get("Tipo_Envio") == "📍 Pedido Local" and origen_tab in ["Mañana", "Tarde"]:
-                    turno_options = ["", "☀️ Local Mañana", "🌙 Local Tarde"]
-                    if st.session_state[turno_key] not in turno_options:
-                        st.session_state[turno_key] = turno_options[0]
-
-                    st.selectbox(
-                        "Clasificar turno como:",
-                        options=turno_options,
-                        key=turno_key,
+                    st.date_input(
+                        "Nueva fecha:",
+                        value=st.session_state[fecha_key],
+                        min_value=today,
+                        max_value=today + timedelta(days=365),
+                        format="DD/MM/YYYY",
+                        key=fecha_key,
                     )
 
-                if st.button(
-                    "✅ Aplicar Cambios de Fecha/Turno",
-                    key=f"btn_apply_{row['ID_Pedido']}",
-                ):
-                    st.session_state["expanded_pedidos"][row['ID_Pedido']] = True
-                    cambios = []
-                    nueva_fecha_str = st.session_state[fecha_key].strftime('%Y-%m-%d')
+                    if row.get("Tipo_Envio") == "📍 Pedido Local" and origen_tab in ["Mañana", "Tarde"]:
+                        turno_options = ["", "☀️ Local Mañana", "🌙 Local Tarde"]
+                        if st.session_state[turno_key] not in turno_options:
+                            st.session_state[turno_key] = turno_options[0]
 
-                    if nueva_fecha_str != fecha_actual_str:
-                        col_idx = headers.index("Fecha_Entrega") + 1
-                        cambios.append(
-                            {
-                                'range': gspread.utils.rowcol_to_a1(
-                                    gsheet_row_index, col_idx
-                                ),
-                                'values': [[nueva_fecha_str]],
-                            }
+                        st.selectbox(
+                            "Clasificar turno como:",
+                            options=turno_options,
+                            key=turno_key,
                         )
 
-                    if row.get("Tipo_Envio") == "📍 Pedido Local" and origen_tab in ["Mañana", "Tarde"]:
-                        nuevo_turno = st.session_state[turno_key]
-                        if nuevo_turno != current_turno:
-                            col_idx = headers.index("Turno") + 1
+                    col_apply, col_cancel, _ = st.columns([1, 1, 2])
+                    apply_clicked = col_apply.button(
+                        "✅ Aplicar Cambios de Fecha/Turno",
+                        key=f"btn_apply_{row['ID_Pedido']}",
+                    )
+                    cancel_clicked = col_cancel.button(
+                        "❌ Cancelar",
+                        key=f"btn_cancel_fecha_{row['ID_Pedido']}",
+                    )
+
+                    if cancel_clicked:
+                        st.session_state["pedido_en_edicion"] = None
+
+                    if apply_clicked:
+                        st.session_state["expanded_pedidos"][row['ID_Pedido']] = True
+                        cambios = []
+                        nueva_fecha = st.session_state[fecha_key]
+                        nueva_fecha_str = nueva_fecha.strftime('%Y-%m-%d')
+
+                        if nueva_fecha_str != fecha_actual_str:
+                            col_idx = headers.index("Fecha_Entrega") + 1
                             cambios.append(
                                 {
                                     'range': gspread.utils.rowcol_to_a1(
                                         gsheet_row_index, col_idx
                                     ),
-                                    'values': [[nuevo_turno]],
+                                    'values': [[nueva_fecha_str]],
                                 }
                             )
 
-                    if cambios:
-                        if batch_update_gsheet_cells(worksheet, cambios):
-                            if "Fecha_Entrega" in headers:
-                                df.at[idx, "Fecha_Entrega"] = nueva_fecha_str
-                            if (
-                                "Turno" in headers
-                                and row.get("Tipo_Envio") == "📍 Pedido Local"
-                            ):
-                                df.at[idx, "Turno"] = st.session_state[turno_key]
+                        if row.get("Tipo_Envio") == "📍 Pedido Local" and origen_tab in ["Mañana", "Tarde"]:
+                            nuevo_turno = st.session_state[turno_key]
+                            if nuevo_turno != current_turno:
+                                col_idx = headers.index("Turno") + 1
+                                cambios.append(
+                                    {
+                                        'range': gspread.utils.rowcol_to_a1(
+                                            gsheet_row_index, col_idx
+                                        ),
+                                        'values': [[nuevo_turno]],
+                                    }
+                                )
 
-                            st.toast(
-                                f"📅 Pedido {row['ID_Pedido']} actualizado.",
-                                icon="✅",
-                            )
+                        if cambios:
+                            if batch_update_gsheet_cells(worksheet, cambios):
+                                if "Fecha_Entrega" in headers:
+                                    df.at[idx, "Fecha_Entrega"] = nueva_fecha_str
+                                if (
+                                    "Turno" in headers
+                                    and row.get("Tipo_Envio") == "📍 Pedido Local"
+                                ):
+                                    df.at[idx, "Turno"] = st.session_state[turno_key]
+
+                                st.toast(
+                                    f"📅 Pedido {row['ID_Pedido']} actualizado.",
+                                    icon="✅",
+                                )
+                                st.session_state["pedido_en_edicion"] = None
+                            else:
+                                st.error("❌ Falló la actualización en Google Sheets.")
                         else:
-                            st.error("❌ Falló la actualización en Google Sheets.")
-                    else:
-                        st.info("No hubo cambios para aplicar.")
+                            st.info("No hubo cambios para aplicar.")
+            else:
+                if st.button(
+                    "📅 Cambiar Fecha y Turno",
+                    key=f"btn_editar_fecha_{row['ID_Pedido']}",
+                ):
+                    st.session_state["pedido_en_edicion"] = row["ID_Pedido"]
+                    if fecha_key not in st.session_state:
+                        st.session_state[fecha_key] = default_fecha
+                    if turno_key not in st.session_state:
+                        st.session_state[turno_key] = current_turno
 
 
         


### PR DESCRIPTION
## Summary
- add session state bookkeeping to track which pedido is currently being edited
- replace the checkbox-based fecha/turno editor with a single button-triggered container and cancel/apply handling that clears state after updates

## Testing
- python -m compileall app_a-d.py

------
https://chatgpt.com/codex/tasks/task_e_68c9ccbf3cf0832687ecfc77395cb4d7