### PR TITLE
Ajusta turno para pedidos de cursos y eventos

### DIFF
--- a/app_i-d.py
+++ b/app_i-d.py
@@ -487,6 +487,13 @@ with tabs[0]:
                 & (df_local["Completados_Limpiado"].astype(str).str.lower() == "sí")
             )
         ]
+        if "Turno" not in df_local.columns:
+            df_local["Turno"] = ""
+        df_local["Turno"] = df_local["Turno"].fillna("").astype(str)
+        df_local.loc[df_local["Turno"].str.lower() == "nan", "Turno"] = ""
+        mask_curso_evento = df_local["Tipo_Envio"] == "🎓 Cursos y Eventos"
+        mask_turno_vacio = df_local["Turno"].str.strip() == ""
+        df_local.loc[mask_curso_evento & mask_turno_vacio, "Turno"] = "🎓 Cursos y Eventos"
         if df_local.empty:
             st.info("Sin pedidos locales.")
         else:


### PR DESCRIPTION
## Summary
- normaliza la columna Turno antes de generar pestañas locales
- asigna la etiqueta "🎓 Cursos y Eventos" como turno cuando esos pedidos no tienen turno definido

## Testing
- python -m compileall app_i-d.py

------
https://chatgpt.com/codex/tasks/task_e_68d56e3e4174832699e633f77af866a3