### PR TITLE
Ensure guide uploads refresh the UI immediately

### DIFF
--- a/app_a-d.py
+++ b/app_a-d.py
@@ -1513,6 +1513,9 @@ def mostrar_pedido(df, idx, row, orden, origen_tab, current_main_tab_label, work
                                 st.success(
                                     f"📦 Se subieron correctamente {len(uploaded_keys)} archivo(s) de guía."
                                 )
+                                st.cache_data.clear()
+                                st.cache_resource.clear()
+                                st.rerun()
                             else:
                                 st.error(
                                     "❌ No se pudo actualizar el Google Sheet con los archivos de guía."


### PR DESCRIPTION
## Summary
- clear Streamlit cache layers after uploading shipping guides so fresh data is displayed
- trigger an immediate rerun following successful uploads to show updated attachment URLs

## Testing
- not run (Streamlit app change)


------
https://chatgpt.com/codex/tasks/task_e_68d5e39083f48326b5fa55a4bf451d25