### PR TITLE
Actualizar detalles de tarjetas automáticas

### DIFF
--- a/app_i-d.py
+++ b/app_i-d.py
@@ -210,10 +210,6 @@ def build_entries_local(df_local: pd.DataFrame):
         entry = build_base_entry(row, "📍 Local")
         badges = unique_preserve([entry["turno"], entry["tipo_envio"]])
         details = []
-        if entry["id_pedido"]:
-            details.append(f"🆔 {entry['id_pedido']}")
-        if entry["vendedor"]:
-            details.append(f"👤 {entry['vendedor']}")
         entry["badges"] = badges
         entry["details"] = unique_preserve(details)
         entries.append(entry)
@@ -226,12 +222,8 @@ def build_entries_casos(df_casos: pd.DataFrame):
         entry = build_base_entry(row, "🧰 Casos")
         badges = unique_preserve([entry["tipo"], entry["turno"], entry["tipo_envio_original"]])
         details = []
-        if entry["id_pedido"]:
-            details.append(f"🆔 {entry['id_pedido']}")
         if entry["tipo_envio"] and entry["tipo_envio"] not in badges:
             details.append(f"🚚 {entry['tipo_envio']}")
-        if entry["vendedor"]:
-            details.append(f"👤 {entry['vendedor']}")
         entry["badges"] = badges
         entry["details"] = unique_preserve(details)
         entries.append(entry)
@@ -244,12 +236,8 @@ def build_entries_foraneo(df_for: pd.DataFrame):
         entry = build_base_entry(row, "🌍 Foráneo")
         badges = unique_preserve([entry["tipo_envio"], entry["turno"]])
         details = []
-        if entry["id_pedido"]:
-            details.append(f"🆔 {entry['id_pedido']}")
         if entry["tipo_envio_original"] and entry["tipo_envio_original"] not in badges:
             details.append(f"📦 {entry['tipo_envio_original']}")
-        if entry["vendedor"]:
-            details.append(f"👤 {entry['vendedor']}")
         entry["badges"] = badges
         entry["details"] = unique_preserve(details)
         entries.append(entry)
@@ -262,10 +250,6 @@ def build_entries_cdmx(df_cdmx: pd.DataFrame):
         entry = build_base_entry(row, "🏙️ CDMX")
         badges = unique_preserve(["🏙️ Pedido CDMX", entry["tipo_envio"]])
         details = []
-        if entry["id_pedido"]:
-            details.append(f"🆔 {entry['id_pedido']}")
-        if entry["vendedor"]:
-            details.append(f"👤 {entry['vendedor']}")
         entry["badges"] = badges
         entry["details"] = unique_preserve(details)
         entries.append(entry)
@@ -278,10 +262,6 @@ def build_entries_guias(df_guias: pd.DataFrame):
         entry = build_base_entry(row, "📋 Guía")
         badges = unique_preserve(["📋 Solicitud de Guía", entry["tipo_envio"]])
         details = []
-        if entry["id_pedido"]:
-            details.append(f"🆔 {entry['id_pedido']}")
-        if entry["vendedor"]:
-            details.append(f"👤 {entry['vendedor']}")
         entry["badges"] = badges
         entry["details"] = unique_preserve(details)
         entries.append(entry)
@@ -305,14 +285,9 @@ def render_auto_cards(entries, layout: str = "small"):
                 f"<span class='auto-card-badge'>{badge}</span>" for badge in badges
             ) + "</div>"
 
-        meta_parts = []
-        if entry.get("fecha"):
-            meta_parts.append(f"📅 {entry['fecha']}")
-        if entry.get("hora"):
-            meta_parts.append(f"⏰ {entry['hora']}")
         meta_html = (
-            "<div class='auto-card-meta'>" + " · ".join(meta_parts) + "</div>"
-            if meta_parts
+            f"<div class='auto-card-meta'>📅 Fecha Entrega: {entry['fecha']}</div>"
+            if entry.get("fecha")
             else ""
         )
 


### PR DESCRIPTION
## Summary
- eliminar los detalles de ID de pedido y vendedor en los listados automáticos
- mostrar únicamente la fecha de entrega en la sección meta de las tarjetas

## Testing
- streamlit run app_i-d.py --server.port 8501 --server.headless true *(fails: faltan credenciales de AWS S3)*

------
https://chatgpt.com/codex/tasks/task_e_68d8a6cdd73083269527d6596ade05d8