### PR TITLE
Detect text or attachment-based surtido mods

### DIFF
--- a/app_a-d.py
+++ b/app_a-d.py
@@ -1953,9 +1953,40 @@ if not df_main.empty:
         st.rerun()
 
     # --- 🔔 Alerta de Modificación de Surtido ---  
+    def has_real_attachment(value):
+        if isinstance(value, (list, tuple, set)):
+            return any(has_real_attachment(item) for item in value)
+
+        if value is None:
+            return False
+
+        if isinstance(value, float) and pd.isna(value):
+            return False
+
+        if isinstance(value, str):
+            cleaned_value = value.strip()
+            if cleaned_value.lower() in ("", "[]", "null", "none"):
+                return False
+
+            try:
+                parsed_value = json.loads(cleaned_value)
+            except (json.JSONDecodeError, TypeError, ValueError):
+                return True
+
+            return has_real_attachment(parsed_value)
+
+        return True
+
+    mod_surtido_text_mask = (
+        df_main['Modificacion_Surtido'].astype(str).str.strip() != ''
+    ) & (
+        ~df_main['Modificacion_Surtido'].astype(str).str.endswith('[✔CONFIRMADO]')
+    )
+
+    mod_surtido_attachment_mask = df_main['Adjuntos_Surtido'].apply(has_real_attachment)
+
     mod_surtido_df = df_main[
-        (df_main['Modificacion_Surtido'].astype(str).str.strip() != '') &
-        (~df_main['Modificacion_Surtido'].astype(str).str.endswith('[✔CONFIRMADO]')) &
+        (mod_surtido_text_mask | mod_surtido_attachment_mask) &
         (~df_main['Estado'].isin(['🟢 Completado', '✅ Viajó'])) &
         (df_main['Refacturacion_Tipo'].fillna("").str.strip() != "Datos Fiscales")
     ]


### PR DESCRIPTION
## Summary
- extend the surtido modification alert to consider either textual updates or meaningful attachments
- ignore empty attachment markers such as empty strings, JSON arrays, or null values when building the alert

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db49b0fc148326ac7e6a73986eba2a