### PR TITLE
Unificar turnos Local Mañana/Tarde en 🌤️ Local Día (Auto Local)

### DIFF
--- a/app_i-d.py
+++ b/app_i-d.py
@@ -4396,8 +4396,7 @@ if selected_tab == 2:
     )
 
     turno_priority = [
-        "☀️ Local Mañana",
-        "🌙 Local Tarde",
+        "🌤️ Local Día",
         "🌵 Saltillo",
         "📦 Pasa a Bodega",
         "📍 Local (sin turno)",
@@ -4405,6 +4404,8 @@ if selected_tab == 2:
     grouped: dict[str, list] = {label: [] for label in turno_priority}
     for entry in combined_entries:
         turno = normalize_turno_label(entry.get("turno", ""))
+        if turno in {"☀️ Local Mañana", "🌙 Local Tarde"}:
+            turno = "🌤️ Local Día"
         if not turno:
             turno = "📍 Local (sin turno)"
         if turno not in grouped:


### PR DESCRIPTION
### Motivation

- Consolidar la visualización de pedidos locales para que los turnos `☀️ Local Mañana` y `🌙 Local Tarde` aparezcan juntos bajo una única categoría `🌤️ Local Día` en la pestaña Auto Local.

### Description

- Reemplacé las entradas `☀️ Local Mañana` y `🌙 Local Tarde` por `🌤️ Local Día` en la lista de prioridad `turno_priority` dentro del bloque `if selected_tab == 2` en `app_i-d.py`.
- Añadí una normalización previa al agrupado que reasigna `turno` a `"🌤️ Local Día"` cuando su valor es `☀️ Local Mañana` o `🌙 Local Tarde` antes de construir `grouped`.
- Los cambios están limitados a `app_i-d.py` y mantienen la lógica de agrupado/ordenación existente (se conservan `Saltillo`, `Pasa a Bodega` y `Local (sin turno)`).

### Testing

- Ejecuté `python -m py_compile app_i-d.py` y la compilación fue exitosa.
- Se verificó que el archivo modificado puede importarse sin errores de sintaxis (compilación pasada).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d999b61cc0832685f286b172c61b4f)