### PR TITLE
Eliminar expander duplicado de archivos en Devoluciones (app_a)

### DIFF
--- a/app_a-d.py
+++ b/app_a-d.py
@@ -6448,32 +6448,6 @@ if df_main is not None:
     
                 st.markdown("---")
     
-                with st.expander("📎 Archivos del Caso", expanded=False):
-                    adjuntos_urls = _normalize_urls(row.get("Adjuntos", ""))
-                    nota_credito_url = str(row.get("Nota_Credito_URL", "")).strip()
-                    documento_adic_url = str(row.get("Documento_Adicional_URL", "")).strip()
-    
-                    items = []
-                    for u in adjuntos_urls:
-                        file_name = os.path.basename(u)
-                        items.append((file_name, resolve_storage_url(s3_client, u)))
-    
-                    if nota_credito_url and nota_credito_url.lower() not in ("nan", "none", "n/a"):
-                        items.append(("Nota de Crédito", resolve_storage_url(s3_client, nota_credito_url)))
-                    if documento_adic_url and documento_adic_url.lower() not in ("nan", "none", "n/a"):
-                        items.append(("Documento Adicional", resolve_storage_url(s3_client, documento_adic_url)))
-    
-                    if items:
-                        for label, url in items:
-                            st.markdown(
-                                f'- <a href="{url}" target="_blank">{label}</a>',
-                                unsafe_allow_html=True,
-                            )
-                    else:
-                        st.info("No hay archivos registrados para esta devolución.")
-    
-                st.markdown("---")
-    
                 with st.expander("📋 Documentación", expanded=False):
                     st.caption("La guía es opcional; puedes completar la devolución sin subirla.")
                     success_placeholder = st.empty()


### PR DESCRIPTION
### Motivation
- Había una duplicidad visual en la pestaña Devoluciones donde se mostraban dos bloques de archivos iguales por caso, lo que generaba redundancia y confusión.

### Description
- Se eliminó el expander `📎 Archivos del Caso` que aparecía después de la sección de Modificación de Surtido en `app_a-d.py`, conservando el expander principal `📎 Archivos (Adjuntos y Guía)` y la sección `📋 Documentación` para la carga de guías.

### Testing
- Se compiló el archivo con `python -m py_compile app_a-d.py` y la verificación fue exitosa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd836c2c648326b32a71854488121f)