### PR TITLE
Excluir turnos CDMX/aula del aviso de Modificación de Surtido

### DIFF
--- a/app_a-d.py
+++ b/app_a-d.py
@@ -4950,8 +4950,12 @@ if df_main is not None:
 
 
     # --- 🔔 Alerta de Modificación de Surtido ---
-    mod_surtido_main_df = _pending_modificaciones(df_main)
-    mod_surtido_casos_df = _pending_modificaciones(df_casos)
+    mod_surtido_main_df = _pending_modificaciones(
+        _exclude_turnos_from_status_view(df_main)
+    )
+    mod_surtido_casos_df = _pending_modificaciones(
+        _exclude_turnos_from_status_view(df_casos)
+    )
 
     mod_surtido_count = len(mod_surtido_main_df) + len(mod_surtido_casos_df)
 


### PR DESCRIPTION
### Motivation
- Alinear el aviso global de "Modificación de Surtido" con la lógica de vistas/métricas para evitar que se contabilicen pedidos con turnos excluidos como `Local CDMX` o `Recoge en Aula` y así reducir falsos positivos en el contador.

### Description
- Se filtró `df_main` y `df_casos` con la función ` _exclude_turnos_from_status_view` antes de pasar las filas a `_pending_modificaciones` en `app_a-d.py` para calcular el aviso solamente sobre pedidos relevantes.
- No se cambiaron las funciones de conteo ni la presentación del aviso; `collect_tab_locations` sigue usando los DataFrames resultantes para construir la cadena de ubicaciones.

### Testing
- Se ejecutó `python -m py_compile app_a-d.py` y la compilación fue exitosa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de8e35b3e4832696d90f0c0f73a1bc)