### PR TITLE
Permitir guardar comprobante con monto 0 si se adjunta archivo

### DIFF
--- a/app_a-d.py
+++ b/app_a-d.py
@@ -3636,8 +3636,8 @@ def mostrar_pedido(df, idx, row, orden, origen_tab, current_main_tab_label, work
                     terminal_pago = st.session_state.get(terminal_pago_key, terminal_default)
                     usa_terminal = forma_pago in ["Tarjeta de Débito", "Tarjeta de Crédito"]
 
-                    if monto_pago <= 0:
-                        st.warning("⚠️ Captura un monto mayor a 0 para guardar el comprobante.")
+                    if not archivos_comprobante:
+                        st.warning("⚠️ Debes subir al menos un comprobante para guardar.")
                     else:
                         updates = []
                         campos_valores = {


### PR DESCRIPTION
### Motivation
- Evitar que la validación impida guardar comprobantes cuando el monto es cero, permitiendo guardar siempre que se adjunte al menos un archivo en el control de `📎 Subir Comprobante(s)`.

### Description
- Se modificó la validación en `app_a-d.py` reemplazando la comprobación `if monto_pago <= 0` por `if not archivos_comprobante` para requerir sólo archivos al guardar el comprobante. 
- Se mantiene el comportamiento existente de actualizar metadatos de pago y establecer `Estado_Pago` a `✅ Pagado` cuando se realiza el guardado con archivos adjuntos.

### Testing
- Se ejecutó `python -m py_compile app_a-d.py` y la verificación de sintaxis completó sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de9fe2330c83269cb1da6d7f3ba44a)