### PR TITLE
Consolidar turnos locales a "🌤️ Local Día" en app_gerente

### DIFF
--- a/app_gerente.py
+++ b/app_gerente.py
@@ -5516,7 +5516,7 @@ if "modificar" in tab_map:
                 tipo_envio = st.selectbox("➡️ Cambiar a:", [opcion_contraria])
 
                 if tipo_envio == "📍 Pedido Local":
-                    nuevo_turno = st.selectbox("⏰ Turno", ["☀️ Local Mañana", "🌙 Local Tarde", "🌵 Saltillo", "📦 Pasa a Bodega"])
+                    nuevo_turno = st.selectbox("⏰ Turno", ["🌤️ Local Día", "🌵 Saltillo", "📦 Pasa a Bodega"])
                     fecha_entrega_actual_raw = str(row.get("Fecha_Entrega", "") or "").strip()
                     fecha_entrega_actual_dt = pd.to_datetime(fecha_entrega_actual_raw, errors="coerce")
                     fecha_entrega_actual_mostrar = (


### PR DESCRIPTION
### Motivation
- Simplificar la selección de turno al cambiar un pedido a `📍 Pedido Local` consolidando las opciones de mañana/tarde en una sola etiqueta uniforme para UI y almacenamiento.

### Description
- En `app_gerente.py` ajusté el `st.selectbox` de `⏰ Turno` dentro del expandible `🚚 Cambio de Tipo de Envío — Ajustar logística` para que las opciones sean `["🌤️ Local Día", "🌵 Saltillo", "📦 Pasa a Bodega"]` en lugar de separar `☀️ Local Mañana` y `🌙 Local Tarde`.
- El cambio asegura que el valor guardado en la hoja/Excel al aplicar la modificación para pedidos locales sea exactamente `🌤️ Local Día` cuando corresponda.

### Testing
- Ejecuté la comprobación de sintaxis con `python -m py_compile app_gerente.py` y la verificación pasó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfeff9bcb88326b52a9eb0230a0d01)