### PR TITLE
Mejora búsqueda de cliente: coincidencia por tokens en cualquier orden

### DIFF
--- a/app_gerente.py
+++ b/app_gerente.py
@@ -1359,6 +1359,27 @@ def normalizar_folio(texto):
     return limpio_sin_espacios.upper()
 
 
+def tokenizar_texto(texto):
+    """Divide texto normalizado en tokens alfanuméricos (sin importar el orden)."""
+    texto_norm = normalizar(str(texto or "").strip())
+    return [tok for tok in re.findall(r"[a-z0-9]+", texto_norm) if tok]
+
+
+def coincide_nombre_cliente(keyword_normalizado, nombre_normalizado):
+    """Compara nombre por subcadena exacta o por coincidencia de tokens en cualquier orden."""
+    if not keyword_normalizado or not nombre_normalizado:
+        return False
+    if keyword_normalizado in nombre_normalizado:
+        return True
+
+    tokens_keyword = tokenizar_texto(keyword_normalizado)
+    if not tokens_keyword:
+        return False
+
+    tokens_nombre = set(tokenizar_texto(nombre_normalizado))
+    return all(token in tokens_nombre for token in tokens_keyword)
+
+
 def obtener_fecha_modificacion(row):
     """Devuelve la fecha de modificación sin importar el nombre exacto de la columna."""
     return str(row.get("Fecha_Modificacion") or row.get("fecha_modificacion") or "").strip()
@@ -4294,7 +4315,10 @@ with tab_map["buscar"]:
                 nombre_normalizado = normalizar(nombre) if nombre else ""
                 folio_normalizado = normalizar_folio(folio)
 
-                coincide_cliente = bool(nombre) and keyword_cliente_normalizado in nombre_normalizado
+                coincide_cliente = bool(nombre) and coincide_nombre_cliente(
+                    keyword_cliente_normalizado,
+                    nombre_normalizado,
+                )
                 coincide_folio = bool(folio_normalizado) and keyword_folio_normalizado == folio_normalizado
 
                 if not coincide_cliente and not coincide_folio:
@@ -4367,7 +4391,10 @@ with tab_map["buscar"]:
                 nombre_normalizado = normalizar(nombre) if nombre else ""
                 folio_normalizado = normalizar_folio(folio)
 
-                coincide_cliente = bool(nombre) and keyword_cliente_normalizado in nombre_normalizado
+                coincide_cliente = bool(nombre) and coincide_nombre_cliente(
+                    keyword_cliente_normalizado,
+                    nombre_normalizado,
+                )
                 coincide_folio = bool(folio_normalizado) and keyword_folio_normalizado == folio_normalizado
 
                 if not coincide_cliente and not coincide_folio:


### PR DESCRIPTION
### Motivation
- Mejorar la búsqueda de la pestaña `🔍 Buscar Pedido` (modo `🧑 Por cliente/factura`) para que, además de la coincidencia por subcadena, también se puedan comparar nombres por `tokens` (palabras) en cualquier orden, permitiendo por ejemplo que `Denisse Ramos` encuentre `DENISSE RUBI RAMOS CAMPO`.

### Description
- Se añadió el helper `tokenizar_texto` que normaliza y divide un texto en tokens alfanuméricos.
- Se añadió la función `coincide_nombre_cliente` que primero intenta la coincidencia por subcadena y, si no coincide, verifica que todos los tokens de la búsqueda estén presentes en el nombre objetivo en cualquier orden.
- Se reemplazó la lógica de `coincide_cliente` en ambos bucles de búsqueda (pedidos y `casos_especiales`) para usar `coincide_nombre_cliente` en `app_gerente.py`.
- Los cambios están localizados en `app_gerente.py` y preservan la coincidencia por subcadena existente como primera opción.

### Testing
- Se ejecutó `python -m py_compile app_gerente.py` y la comprobación de bytecode completó sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e106cc0c108326bf51f2e3b4425708)