### PR TITLE
Excluir tipo de envío 'Pedidos CDMX' de vistas de estado y métricas

### DIFF
--- a/app_a-d.py
+++ b/app_a-d.py
@@ -429,19 +429,32 @@ _EXCLUDED_TURNOS_STATUS_VIEW = {
     "Recoge en Aula",
 }
 
+_EXCLUDED_TIPO_ENVIO_STATUS_VIEW = {
+    "🏙️ Pedidos CDMX",
+    "Pedidos CDMX",
+}
+
 
 def _exclude_turnos_from_status_view(df: pd.DataFrame) -> pd.DataFrame:
-    """Exclude specific turnos from status views and metrics."""
+    """Exclude turnos/tipos de envío específicos de vistas de estado y métricas."""
 
-    if df is None or df.empty or "Turno" not in df.columns:
+    if df is None or df.empty:
         return df
 
-    turno_series = df["Turno"].astype(str).str.strip()
-    mask_excluded_turno = turno_series.isin(_EXCLUDED_TURNOS_STATUS_VIEW)
-    if not mask_excluded_turno.any():
+    mask_excluded = pd.Series(False, index=df.index)
+
+    if "Turno" in df.columns:
+        turno_series = df["Turno"].astype(str).str.strip()
+        mask_excluded |= turno_series.isin(_EXCLUDED_TURNOS_STATUS_VIEW)
+
+    if "Tipo_Envio" in df.columns:
+        tipo_envio_series = df["Tipo_Envio"].astype(str).str.strip()
+        mask_excluded |= tipo_envio_series.isin(_EXCLUDED_TIPO_ENVIO_STATUS_VIEW)
+
+    if not mask_excluded.any():
         return df
 
-    return df.loc[~mask_excluded_turno].copy()
+    return df.loc[~mask_excluded].copy()
 
 
 def _build_turno_options_for_local_change(origen_tab: str) -> list[str]:


### PR DESCRIPTION
### Motivation
- Los pedidos con clasificación CDMX estaban siendo ignorados sólo por `Turno`, pero hay variantes donde `Tipo_Envio` contiene `Pedidos CDMX` que deben excluirse de métricas y avisos. 
- Evitar que estos pedidos influyan en los contadores y alertas mejora la precisión de las vistas y notificaciones para el resto de operaciones.

### Description
- Se agregó la constante `_EXCLUDED_TIPO_ENVIO_STATUS_VIEW` con las variantes `"🏙️ Pedidos CDMX"` y `"Pedidos CDMX"`.
- Se actualizó `_exclude_turnos_from_status_view` para construir un `mask_excluded` que combine exclusiones por `Turno` y por `Tipo_Envio` sólo si esas columnas existen en el `DataFrame`.
- La función ahora retorna una copia filtrada de `df` excluyendo filas que coincidan con cualquiera de los dos criterios, manteniendo el comportamiento anterior cuando ninguna fila coincide.

### Testing
- Se compiló el módulo con `python -m py_compile app_a-d.py` y la verificación de sintaxis finalizó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e127fdcf14832684c7d2138de068dc)