### PR TITLE
Hide original route files when corresponding 'hoja_ruta_mod_' files exist

### DIFF
--- a/app_a-d.py
+++ b/app_a-d.py
@@ -2506,6 +2506,51 @@ def _merge_uploaded_urls(existing_value, new_urls: Sequence[str]) -> str:
     return ", ".join(unique_urls)
 
 
+def _filter_out_original_route_when_modified(files: Sequence[str]) -> list[str]:
+    """Hide original route files when a modified route version is also present.
+
+    Example:
+    - ``ADRIAN_MARCELO.xlsx``
+    - ``hoja_ruta_mod_ADRIAN_MARCELO.xlsx``
+
+    In that case, only the ``hoja_ruta_mod_...`` file should be displayed.
+    """
+    if not files:
+        return []
+
+    originals_hidden = _collect_original_route_names_from_modified(files)
+    normalized_by_raw: dict[str, str] = {}
+
+    for raw in files:
+        name = os.path.basename(urlparse(str(raw)).path) or str(raw)
+        name = unquote(name).strip()
+        normalized_name = name.lower()
+        normalized_by_raw[str(raw)] = normalized_name
+
+    filtered_files: list[str] = []
+    for raw in files:
+        normalized_name = normalized_by_raw.get(str(raw), "")
+        if normalized_name and normalized_name in originals_hidden:
+            continue
+        filtered_files.append(raw)
+
+    return filtered_files
+
+
+def _collect_original_route_names_from_modified(files: Sequence[str]) -> set[str]:
+    """Collect original route filenames implied by `hoja_ruta_mod_...` files."""
+    mod_prefix = "hoja_ruta_mod_"
+    originals_hidden: set[str] = set()
+    for raw in files or []:
+        name = os.path.basename(urlparse(str(raw)).path) or str(raw)
+        name = unquote(name).strip().lower()
+        if name.startswith(mod_prefix):
+            original_name = name[len(mod_prefix):]
+            if original_name:
+                originals_hidden.add(original_name)
+    return originals_hidden
+
+
 def _is_row_empty(row: Any) -> bool:
     """Return True if ``row`` should be treated as empty."""
 
@@ -3565,9 +3610,13 @@ def mostrar_pedido(df, idx, row, orden, origen_tab, current_main_tab_label, work
         ):
             contenido_attachments = False
             sheet_attachments = _normalize_urls(row.get("Adjuntos", ""))
+            sheet_attachments = _filter_out_original_route_when_modified(sheet_attachments)
             sheet_attachment_keys = {
                 extract_s3_key(att) for att in sheet_attachments if att
             }
+            originals_hidden_by_sheet_mod = _collect_original_route_names_from_modified(
+                sheet_attachments
+            )
 
             if sheet_attachments:
                 contenido_attachments = True
@@ -3597,6 +3646,20 @@ def mostrar_pedido(df, idx, row, orden, origen_tab, current_main_tab_label, work
                         f for f in files_in_folder
                         if "comprobante" not in f['title'].lower() and "surtido" not in f['title'].lower()
                     ]
+                    folder_titles = [f.get("title", "") for f in filtered_files_to_display]
+                    visible_titles = set(
+                        _filter_out_original_route_when_modified(folder_titles)
+                    )
+                    filtered_files_to_display = [
+                        f for f in filtered_files_to_display
+                        if f.get("title", "") in visible_titles
+                    ]
+                    if originals_hidden_by_sheet_mod:
+                        filtered_files_to_display = [
+                            f for f in filtered_files_to_display
+                            if str(f.get("title", "")).strip().lower()
+                            not in originals_hidden_by_sheet_mod
+                        ]
                     filtered_files_to_display = [
                         f for f in filtered_files_to_display
                         if extract_s3_key(f['key']) not in sheet_attachment_keys


### PR DESCRIPTION
### Motivation

- Prevent displaying original route files (e.g. `ADRIAN_MARCELO.xlsx`) when a modified route file prefixed with `hoja_ruta_mod_` is present, avoiding duplicate/obsolete attachments in the UI.

### Description

- Added `_filter_out_original_route_when_modified(files: Sequence[str])` to hide original route filenames when a `hoja_ruta_mod_...` counterpart exists, normalizing names and preserving order.
- Added helper `_collect_original_route_names_from_modified(files: Sequence[str])` to derive original names implied by `hoja_ruta_mod_` files.
- Integrated filtering into the attachments UI by cleaning `sheet_attachments` and filtering S3 folder listings to exclude originals when modified files are present, while still excluding comprobante/surtido files and avoiding duplicates already linked in the sheet.
- Performed filename normalization using `urlparse` and `unquote` and matched case-insensitively to ensure robust comparisons.

### Testing

- Ran the project's unit test suite with `pytest -q`, and all tests passed.
- Executed the application's attachment display flow locally against a representative S3 prefix and confirmed modified-route files hide original-route entries without affecting other attachment types.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e14d5fc7a08326b874ce8893280d07)