### PR TITLE
Quitar estado de pago duplicado en pedidos locales '📦 En Bodega'

### DIFF
--- a/app_a-d.py
+++ b/app_a-d.py
@@ -3693,9 +3693,6 @@ def mostrar_pedido(df, idx, row, orden, origen_tab, current_main_tab_label, work
                 )
 
         if es_local_bodega:
-            st.markdown("##### 💳 Estado de pago")
-            st.info(f"Estado actual: **{pago_badge}**")
-
             if not pago_confirmado:
                 pago_widget_suffix = f"{row['ID_Pedido']}_{origen_tab}"
                 upload_comp_key = f"uploader_comprobante_{pago_widget_suffix}"


### PR DESCRIPTION
### Motivation
- Evitar la duplicación visual del estado de pago dentro del contenido del pedido cuando ya se muestra en el título del expander para pedidos locales en `📦 En Bodega`.

### Description
- Se eliminaron las dos líneas que mostraban `##### 💳 Estado de pago` y `st.info(f"Estado actual: **{pago_badge}**")` dentro de `if es_local_bodega:` en la función `mostrar_pedido` del archivo `app_a-d.py`, manteniendo el badge de pago en el título del expander.

### Testing
- Se verificó la sintaxis compilando el archivo con `python -m py_compile app_a-d.py` y la comprobación fue exitosa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e24eb524a08326adc2a4995126835a)