### PR TITLE
Exclude completed local orders from 'En Bodega' subtab

### DIFF
--- a/app_a-d.py
+++ b/app_a-d.py
@@ -5969,7 +5969,8 @@ if df_main is not None:
         with subtabs_local[2]: # 📦 En Bodega
             pedidos_b_display = df_pendientes_proceso_demorado[
                 (df_pendientes_proceso_demorado["Tipo_Envio"] == "📍 Pedido Local") &
-                (df_pendientes_proceso_demorado["Turno"] == "📦 Pasa a Bodega")
+                (df_pendientes_proceso_demorado["Turno"] == "📦 Pasa a Bodega") &
+                (df_pendientes_proceso_demorado["Estado"].isin(estados_visibles))
             ].copy()
             if not pedidos_b_display.empty:
                 pedidos_b_display = ordenar_pedidos_custom(pedidos_b_display)


### PR DESCRIPTION
### Motivation
- Fix a UI bug where locally completed orders (e.g. `🟢 Completado`) were shown both in `✅ Historial Completados` and in the `📍 Pedidos Locales > 📦 En Bodega` subtab, causing duplicates.

### Description
- Restrict the `📦 En Bodega` subtab filter to only include rows where `Estado` is in `estados_visibles` by updating the `df_pendientes_proceso_demorado` slice in `app_a-d.py` to add `(df_pendientes_proceso_demorado["Estado"].isin(estados_visibles))` to the existing conditions.

### Testing
- Ran `python -m py_compile app_a-d.py` successfully with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e27a8282ac832693a3665406310ae2)