### PR TITLE
Priorizar `_gsheet_row_index` al procesar devoluciones

### DIFF
--- a/app_a-d.py
+++ b/app_a-d.py
@@ -6536,7 +6536,13 @@ if df_main is not None:
     
                             # Localiza la fila en 'casos_especiales'
                             gsheet_row_idx = None
-                            if "ID_Pedido" in df_casos.columns and idp:
+                            raw_row_idx = row.get("_gsheet_row_index", row.get("gsheet_row_index"))
+                            try:
+                                if raw_row_idx is not None and not pd.isna(raw_row_idx):
+                                    gsheet_row_idx = int(float(raw_row_idx))
+                            except Exception:
+                                gsheet_row_idx = None
+                            if gsheet_row_idx is None and "ID_Pedido" in df_casos.columns and idp:
                                 matches = df_casos.index[df_casos["ID_Pedido"].astype(str).str.strip() == idp]
                                 if len(matches) > 0:
                                     gsheet_row_idx = int(matches[0]) + 2
@@ -6752,7 +6758,13 @@ if df_main is not None:
 
                         # Localiza la fila en 'casos_especiales'
                         gsheet_row_idx = None
-                        if "ID_Pedido" in df_casos.columns and idp:
+                        raw_row_idx = row.get("_gsheet_row_index", row.get("gsheet_row_index"))
+                        try:
+                            if raw_row_idx is not None and not pd.isna(raw_row_idx):
+                                gsheet_row_idx = int(float(raw_row_idx))
+                        except Exception:
+                            gsheet_row_idx = None
+                        if gsheet_row_idx is None and "ID_Pedido" in df_casos.columns and idp:
                             matches = df_casos.index[df_casos["ID_Pedido"].astype(str).str.strip() == idp]
                             if len(matches) > 0:
                                 gsheet_row_idx = int(matches[0]) + 2


### PR DESCRIPTION
### Motivation
- Evitar que las acciones de procesamiento en la pestaña `🔁 Devoluciones` actualicen la fila equivocada cuando hay IDs o folios repetidos, lo que obligaba a varios intentos hasta que el cambio se reflejara.

### Description
- Cambiado el flujo de `🔧 Procesar Modificación` y `⚙️ Procesar` para que primero usen el índice de fila interno `row.get("_gsheet_row_index", row.get("gsheet_row_index"))` (parseado a entero) como `gsheet_row_idx` antes de caer en la búsqueda por `ID_Pedido` o por `Folio_Factura + Cliente`.

### Testing
- Ejecutado `python -m py_compile app_a-d.py` con éxito para validar la sintaxis del archivo modificado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e27c35e9c0832686babcf767fdf98e)