### PR TITLE
Ocultar controles de fecha/turno en Historial Completados

### DIFF
--- a/app_a-d.py
+++ b/app_a-d.py
@@ -3317,6 +3317,10 @@ def mostrar_pedido(df, idx, row, orden, origen_tab, current_main_tab_label, work
 
         es_local_no_entregado = es_pedido_local_no_entregado(row)
         tipo_envio_actual = row.get("Tipo_Envio")
+        es_tab_historial_completados = (
+            str(current_main_tab_label).strip() == "✅ Historial Completados"
+            or str(origen_tab).strip() == "Historial"
+        )
 
         # --- Cambiar Fecha (y turno solo para locales) ---
         puede_cambiar_fecha = (
@@ -3325,6 +3329,7 @@ def mostrar_pedido(df, idx, row, orden, origen_tab, current_main_tab_label, work
                 row['Estado'] not in ["🟢 Completado", "✅ Viajó"]
                 or es_local_no_entregado
             )
+            and not es_tab_historial_completados
         )
         permite_cambiar_turno_local = tipo_envio_actual == "📍 Pedido Local"
         texto_checkbox_cambio = (


### PR DESCRIPTION
### Motivation
- Evitar que en la pestaña `✅ Historial Completados` aparezcan los controles de edición de fecha/turno que antes podían mostrarse para pedidos completados/no entregados y causaban confusión.

### Description
- En `mostrar_pedido` se añadió la comprobación `es_tab_historial_completados` (basada en `current_main_tab_label` u `origen_tab`) y se actualizó la condición `puede_cambiar_fecha` para no mostrar los controles de fecha/turno en ese contexto, ocultando las secciones `Fecha actual`, `Turno actual`, `Estado de entrega` y el formulario `Aplicar Cambios de Fecha/Turno`.

### Testing
- Se compiló el archivo con `python -m py_compile app_a-d.py` y la compilación pasó sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e27da7d9cc832681af1b7bc2966263)