### PR TITLE
Support non-vendor 'SINAI' user and refactor vendor/tab resolution

### DIFF
--- a/app_i-d.py
+++ b/app_i-d.py
@@ -142,7 +142,21 @@ VENDEDOR_CREDENTIALS = {
     "PAULINA57": "PAULINA TREJO",
     "RUBEN67": "RUBEN",
     "ROBERTO51": "DISTRIBUCION Y UNIVERSIDADES",
+    "SINAI": "SINAI",
 }
+
+
+NON_VENDOR_USERS = {"SINAI"}
+
+
+def is_non_vendor_user(user_key: str) -> bool:
+    return sanitize_text(user_key).upper() in NON_VENDOR_USERS
+
+
+def resolve_vendor_for_user(user_key: str) -> str:
+    if is_non_vendor_user(user_key):
+        return ""
+    return sanitize_text(VENDEDOR_CREDENTIALS.get(sanitize_text(user_key).upper(), ""))
 
 st.set_page_config(page_title="Panel de Almacén Integrado", layout="wide")
 
@@ -322,6 +336,9 @@ def clear_query_param(param_name: str) -> None:
 
 
 def get_logged_vendor() -> str:
+    user_key = sanitize_text(st.session_state.get("auth_user", ""))
+    if is_non_vendor_user(user_key):
+        return ""
     return sanitize_text(st.session_state.get("auth_vendor", ""))
 
 
@@ -4106,41 +4123,49 @@ if "show_grouped_panel_casos" not in globals():
 df_all = load_data_from_gsheets()
 
 # Tabs principales
-tab_labels = [
-    "📈 Dashboard",
-    "🧠 Asistente TD",
-    "⚙️ Auto Local",
-    "🚚 Auto Foráneo",
-    "🧑‍🔧 Surtidores",
+TAB_DEFINITIONS = [
+    ("dashboard", "📈 Dashboard"),
+    ("assistant", "🧠 Asistente TD"),
+    ("auto_local", "⚙️ Auto Local"),
+    ("auto_foraneo", "🚚 Auto Foráneo"),
+    ("surtidores", "🧑‍🔧 Surtidores"),
 ]
 
-# ---------------------------
-# Persistencia de tab activa (para autorefresh)
-# ---------------------------
 init_login_state()
 
 if not get_logged_user():
     usuario_qp = get_query_param_value("usuario").upper()
     if usuario_qp in VENDEDOR_CREDENTIALS:
         st.session_state.auth_user = usuario_qp
-        st.session_state.auth_vendor = VENDEDOR_CREDENTIALS[usuario_qp]
+        st.session_state.auth_vendor = resolve_vendor_for_user(usuario_qp)
+
+logged_user = get_logged_user().upper()
+if logged_user == "SINAI":
+    visible_tab_keys = ["auto_foraneo", "auto_local", "assistant"]
+else:
+    visible_tab_keys = [tab_key for tab_key, _ in TAB_DEFINITIONS]
+
+tab_map = dict(TAB_DEFINITIONS)
+visible_tabs = [(tab_key, tab_map[tab_key]) for tab_key in visible_tab_keys if tab_key in tab_map]
+tab_labels = [tab_label for _, tab_label in visible_tabs]
+tab_options = list(range(len(visible_tabs)))
 
 tab_qp = get_query_param_value("tab")
 if "active_main_tab" not in st.session_state:
     st.session_state.active_main_tab = 0
-elif st.session_state.active_main_tab >= len(tab_labels):
+elif st.session_state.active_main_tab >= len(tab_options):
     st.session_state.active_main_tab = 0
 radio_tab_state = st.session_state.get("_radio_main_tab")
-if isinstance(radio_tab_state, int) and 0 <= radio_tab_state < len(tab_labels):
+if isinstance(radio_tab_state, int) and 0 <= radio_tab_state < len(tab_options):
     st.session_state.active_main_tab = radio_tab_state
 elif tab_qp.isdigit():
     tab_index = int(tab_qp)
-    if 0 <= tab_index < len(tab_labels):
+    if 0 <= tab_index < len(tab_options):
         st.session_state.active_main_tab = tab_index
 
 selected_tab = st.radio(
     "Vista",
-    options=list(range(len(tab_labels))),
+    options=tab_options,
     format_func=lambda i: tab_labels[i],
     index=st.session_state.active_main_tab,
     horizontal=True,
@@ -4148,9 +4173,10 @@ selected_tab = st.radio(
     key="_radio_main_tab",
 )
 st.session_state.active_main_tab = selected_tab
+selected_tab_key = visible_tabs[selected_tab][0]
 
 # helper para "simular" tabs
-tabs = [None] * len(tab_labels)
+tabs = [None] * len(visible_tabs)
 
 logged_vendor = get_logged_vendor()
 logged_user = get_logged_user()
@@ -4163,10 +4189,11 @@ else:
 
 with st.sidebar:
     st.markdown("### 👤 Acceso")
-    if logged_vendor:
-        session_label = f"Sesión activa: **{logged_vendor}**"
-        if logged_user:
-            session_label += f" ({logged_user})"
+    if logged_user:
+        if logged_vendor:
+            session_label = f"Sesión activa: **{logged_vendor}** ({logged_user})"
+        else:
+            session_label = f"Sesión activa: **{logged_user}** (recepción)"
         st.success(session_label)
         if st.button("🚪 Cerrar sesión", key="logout_vendor_sidebar"):
             st.session_state.auth_user = ""
@@ -4183,16 +4210,16 @@ with st.sidebar:
             placeholder="Ingresa tu usuario",
         ).strip().upper()
         if st.button("🔐 Iniciar sesión", key="vendor_login_sidebar_btn"):
-            vendor_name = VENDEDOR_CREDENTIALS.get(user_input, "")
-            if vendor_name:
+            if user_input in VENDEDOR_CREDENTIALS:
+                vendor_name = resolve_vendor_for_user(user_input)
                 st.session_state.auth_user = user_input
                 st.session_state.auth_vendor = vendor_name
-                st.session_state.dashboard_vendedor_sel = vendor_name
+                st.session_state.dashboard_vendedor_sel = vendor_name if vendor_name else "(Todos)"
                 st.query_params["usuario"] = user_input
                 st.rerun()
             st.error("Usuario no válido. Verifica la clave e intenta de nuevo.")
 
-if not logged_vendor:
+if not logged_user:
     st.warning(
         "⚠️ Aún no has iniciado sesión. Para guardar tu usuario en el enlace y evitar volver a loguearte, inicia sesión desde la barra lateral."
     )
@@ -4201,7 +4228,7 @@ if not logged_vendor:
 # Entradas compartidas para numeración única entre Auto Local y Auto Foráneo
 auto_local_entries = []
 auto_foraneo_entries = []
-if selected_tab in (2, 3, 4):
+if selected_tab_key in {"auto_local", "auto_foraneo", "surtidores"}:
     df_local_auto = get_local_orders(df_all)
     casos_local_auto, _ = get_case_envio_assignments(df_all)
     df_local_auto = drop_local_duplicates_for_cases(df_local_auto, casos_local_auto)
@@ -4238,7 +4265,7 @@ if selected_tab in (2, 3, 4):
 # ---------------------------
 # TAB 1: Asistente interno TD
 # ---------------------------
-if selected_tab == 1:
+if selected_tab_key == "assistant":
     init_td_assistant_state()
 
     st.markdown(
@@ -4299,8 +4326,11 @@ if selected_tab == 1:
         """,
         unsafe_allow_html=True,
     )
-    if get_logged_vendor():
-        st.caption(f"Atendiendo como vendedor: {get_logged_vendor()}.")
+    logged_vendor_assistant = get_logged_vendor()
+    if logged_vendor_assistant:
+        st.caption(f"Atendiendo como vendedor: {logged_vendor_assistant}.")
+    elif is_non_vendor_user(get_logged_user()):
+        st.caption("Atendiendo como recepción (consulta general).")
 
     # Fuentes para el asistente interno
     df_casos_assistant = load_casos_from_gsheets()
@@ -4396,7 +4426,7 @@ if selected_tab == 1:
 # ---------------------------
 # TAB 1: Auto Local (Casos asignados) — 2 columnas
 # ---------------------------
-if selected_tab == 2:
+if selected_tab_key == "auto_local":
     st_autorefresh(interval=60000, key="auto_refresh_local_casos")
 
     today_local = datetime.now(TZ).date()
@@ -4458,7 +4488,7 @@ if selected_tab == 2:
 # ---------------------------
 # TAB 2: Auto Foráneo (Casos asignados) — 2 columnas
 # ---------------------------
-if selected_tab == 3:
+if selected_tab_key == "auto_foraneo":
     st_autorefresh(interval=60000, key="auto_refresh_foraneo_cdmx")
 
     hoy = datetime.now(TZ).date()
@@ -4542,7 +4572,7 @@ if selected_tab == 3:
 # ---------------------------
 # TAB 3: Surtidores (Asignación)
 # ---------------------------
-if selected_tab == 4:
+if selected_tab_key == "surtidores":
 
     st.markdown("### 🧑‍🔧 Asignación de surtidores")
     st.caption("Selecciona pedidos visibles y escribe tu nombre o inicial para asignarlos.")
@@ -4684,7 +4714,7 @@ if selected_tab == 4:
             st.info("Sin asignaciones registradas.")
 
 
-if selected_tab == 0:
+if selected_tab_key == "dashboard":
     if st.session_state.pop("_pending_full_refresh", False):
         refresh_dashboard_sources()
 


### PR DESCRIPTION
### Motivation
- Introduce support for a non-vendor user key (`SINAI`) that should behave as a reception/consultation user (no associated vendor). 
- Simplify and make tab visibility and selection dynamic based on logged user instead of using a fixed tab list.
- Centralize vendor resolution and non-vendor checks to avoid scattering special-case logic and to make login/session behavior clearer.

### Description
- Added `SINAI` to `VENDEDOR_CREDENTIALS`, introduced `NON_VENDOR_USERS`, and implemented `is_non_vendor_user` and `resolve_vendor_for_user` helper functions to handle vendor lookup and exceptions for non-vendor users. 
- Updated login flow to use `resolve_vendor_for_user` when setting `st.session_state.auth_vendor` and to set `dashboard_vendedor_sel` to `"(Todos)"` when a non-vendor user is used. 
- Changed `get_logged_vendor` to return an empty string for non-vendor users so downstream UI treats them as reception-only. 
- Replaced the fixed `tab_labels` list with `TAB_DEFINITIONS` and added logic to compute `visible_tabs` and `tab_options` based on the logged user; restricted `SINAI` to only show `auto_foraneo`, `auto_local`, and `assistant` tabs. 
- Switched tab selection and bounds checks to use `tab_options` and introduced `selected_tab_key` (e.g. `"assistant"`, `"auto_local"`) to gate rendering of each tab, replacing numeric `selected_tab` comparisons. 
- Adjusted sidebar session display text to show either the vendor plus user or a reception caption for non-vendor users, and updated login button behavior to validate keys via `VENDEDOR_CREDENTIALS` and `resolve_vendor_for_user`. 
- Touched multiple tab-condition expressions and UI captions so behavior is consistent with the new key-based tab selection and non-vendor semantics.

### Testing
- No automated tests were run as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e27c15fba083268c0942d869ece30e)