### PR TITLE
Ignorar placeholders en Material_Devuelto para evitar filas vacías

### DIFF
--- a/app_a-d.py
+++ b/app_a-d.py
@@ -848,7 +848,12 @@ def _parse_material_devuelto_table(material_text: str) -> Optional[pd.DataFrame]
     if not raw:
         return None
 
-    lines = [line.strip() for line in raw.splitlines() if line.strip()]
+    placeholder_tokens = {"", "empty", "none", "nan", "null", "n/a", "na"}
+    lines = [
+        line.strip()
+        for line in raw.splitlines()
+        if line.strip() and line.strip().lower() not in placeholder_tokens
+    ]
     if len(lines) < 2:
         return None
 
@@ -869,6 +874,8 @@ def _parse_material_devuelto_table(material_text: str) -> Optional[pd.DataFrame]
             parts.extend([""] * (len(headers) - len(parts)))
         elif len(parts) > len(headers):
             parts = parts[: len(headers)]
+        if all((str(cell).strip().lower() in placeholder_tokens) for cell in parts):
+            continue
         rows.append(parts)
 
     if not rows:
@@ -879,7 +886,8 @@ def _parse_material_devuelto_table(material_text: str) -> Optional[pd.DataFrame]
 
 def _render_material_devuelto(material_text: str, empty_text: str = "N/A") -> None:
     material = str(material_text or "").strip()
-    if not material:
+    placeholder_tokens = {"", "empty", "none", "nan", "null", "n/a", "na", "[]", "{}"}
+    if not material or material.lower() in placeholder_tokens:
         st.info(empty_text)
         return
 


### PR DESCRIPTION
### Motivation
- Evitar que valores de placeholder/placeholder-like (por ejemplo `empty`, `none`, `null`, `nan`, `[]`, `{}`) generen tablas con filas vacías o apariencias "rotas" al mostrar `Material_Devuelto` en los casos de Devolución/Garantía.

### Description
- En `app_a-d.py` se introducen `placeholder_tokens` y se filtran líneas que solo contienen tokens placeholder antes de parsear la tabla con `|` en `_parse_material_devuelto_table`.
- Se ignoran renglones cuya totalidad de celdas son placeholders para no incluir filas fantasma en la DataFrame resultante.
- En `_render_material_devuelto` se consideran payloads placeholder (incluyendo `[]` y `{}`) como vacíos para mostrar el texto fallback (`empty_text`) en lugar de intentar renderizar contenido defectuoso.

### Testing
- Se ejecutó `python -m py_compile app_a-d.py` y la verificación de sintaxis compiló correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6a35ed7cc8326a1ca370b88cb6d18)