### PR TITLE
Alinear lógica de número foráneo en pestaña Garantías

### DIFF
--- a/app_a-d.py
+++ b/app_a-d.py
@@ -7605,7 +7605,7 @@ if df_main is not None:
             return out
     
         # ====== RECORRER CADA GARANTÍA ======
-        for orden_garantia, (_, row) in enumerate(garantias_display.iterrows(), start=1):
+        for orden_garantia, (idx, row) in enumerate(garantias_display.iterrows(), start=1):
             idp         = str(row.get("ID_Pedido", "")).strip()
             folio       = str(row.get("Folio_Factura", "")).strip()
             cliente     = str(row.get("Cliente", "")).strip()
@@ -7615,12 +7615,24 @@ if df_main is not None:
             area_resp   = str(row.get("Area_Responsable", "")).strip()
             numero_serie = str(row.get("Numero_Serie", "")).strip()
             fecha_compra = str(row.get("Fecha_Compra", "")).strip()
-            row_key     = (idp or f"{folio}_{cliente}").replace(" ", "_")
+            row_key_base = (idp or f"{folio}_{cliente}").replace(" ", "_") or "sin_id"
+            row_key     = f"{row_key_base}_{idx}"
+
+            tipo_envio_actual = str(row.get("Tipo_Envio_Original", "")).strip()
+            tipo_key   = f"g_tipo_envio_orig_{row_key}"
+            TIPO_OPTS  = ["📍 Pedido Local", "🚚 Pedido Foráneo"]
+
+            if tipo_key not in st.session_state:
+                if tipo_envio_actual in TIPO_OPTS:
+                    st.session_state[tipo_key] = tipo_envio_actual
+                else:
+                    low = tipo_envio_actual.lower()
+                    st.session_state[tipo_key] = "📍 Pedido Local" if "local" in low else "🚚 Pedido Foráneo"
 
             tipo_case = _normalize_text_for_matching(
                 f"{row.get('Tipo_Envio', '')} {row.get('Tipo_Envio_Original', '')}"
             )
-            is_foraneo_case = "foraneo" in tipo_case
+            is_foraneo_case = ("foraneo" in tipo_case) or (st.session_state.get(tipo_key) == "🚚 Pedido Foráneo")
             numero_foraneo_visible = (
                 resolve_case_foraneo_display_number(row, orden_garantia)
                 if is_foraneo_case
@@ -7730,27 +7742,17 @@ if df_main is not None:
                 st.markdown("#### 🚦 Clasificar envío y fecha")
     
                 # Valores actuales
-                tipo_envio_actual = str(row.get("Tipo_Envio_Original", "")).strip()
                 turno_actual      = str(row.get("Turno", "")).strip()
                 fecha_actual_str  = str(row.get("Fecha_Entrega", "")).strip()
                 fecha_actual_dt   = pd.to_datetime(fecha_actual_str, errors='coerce') if fecha_actual_str else None
                 today_date        = (datetime.now(_TZ).date() if _TZ else datetime.now().date())
     
-                tipo_key   = f"g_tipo_envio_orig_{row_key}"
                 turno_key  = f"g_turno_{row_key}"
                 fecha_key  = f"g_fecha_{row_key}"
     
-                TIPO_OPTS  = ["📍 Pedido Local", "🚚 Pedido Foráneo"]
                 TURNO_OPTS = ["🌤️ Local Día", "🌵 Saltillo", "📦 Pasa a Bodega"]
     
                 # Inicialización en session_state
-                if tipo_key not in st.session_state:
-                    if tipo_envio_actual in TIPO_OPTS:
-                        st.session_state[tipo_key] = tipo_envio_actual
-                    else:
-                        low = tipo_envio_actual.lower()
-                        st.session_state[tipo_key] = "📍 Pedido Local" if "local" in low else "🚚 Pedido Foráneo"
-    
                 if turno_key not in st.session_state:
                     st.session_state[turno_key] = turno_actual if turno_actual in TURNO_OPTS else TURNO_OPTS[0]
     


### PR DESCRIPTION
### Motivation
- Evitar inconsistencias entre Devoluciones y Garantías al asignar y mostrar números foráneos al clasificar casos como foráneos.
- Prevenir colisiones de estado entre tarjetas similares usando una clave de fila única por garantía.

### Description
- Actualizado `app_a-d.py` para iterar `garantias_display` con `(idx, row)` y construir un `row_key` único como `f"{row_key_base}_{idx}"` para cada garantía.
- Inicializada la clasificación de `Tipo_Envio_Original` al comienzo de la tarjeta usando `tipo_key` y `TIPO_OPTS` para reutilizar el mismo `session_state` durante toda la UI de la garantía.
- Ajustada la condición `is_foraneo_case` para que sea verdadera cuando la cadena normalizada contiene "foraneo" o cuando `st.session_state.get(tipo_key)` es `"🚚 Pedido Foráneo"`, habilitando la misma UI/flujo de `Numero_Foraneo` que en Devoluciones.
- Eliminada la inicialización duplicada de `tipo_key`/`TIPO_OPTS` en la sección de clasificación para evitar inconsistencias.

### Testing
- Ejecutado `python -m py_compile app_a-d.py` y la compilación de bytecode fue exitosa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6a80f363c8326ac6d869e95c85520)