### PR TITLE
Corregir opciones de turno en Pedidos Locales (Cambiar Fecha y Turno)

### DIFF
--- a/app_a-d.py
+++ b/app_a-d.py
@@ -1010,9 +1010,9 @@ _LOCAL_SUBTAB_OPTIONS = [
 ]
 _LOCAL_NO_ENTREGADOS_TAB_LABEL = "🚫 No entregados"
 _LOCAL_TURNOS_CAMBIO_POR_SUBTAB = {
-    "Mañana": ["🌵 Saltillo", "📦 Pasa a Bodega"],
-    "Tarde": ["🌵 Saltillo", "📦 Pasa a Bodega"],
-    "Local Día": ["🌵 Saltillo", "📦 Pasa a Bodega"],  # compatibilidad
+    "Mañana": ["☀️ Local Mañana", "🌙 Local Tarde", "🌵 Saltillo", "📦 Pasa a Bodega"],
+    "Tarde": ["🌙 Local Tarde", "☀️ Local Mañana", "🌵 Saltillo", "📦 Pasa a Bodega"],
+    "Local Día": ["☀️ Local Mañana", "🌙 Local Tarde", "🌵 Saltillo", "📦 Pasa a Bodega"],  # compatibilidad
     "Saltillo": ["☀️ Local Mañana", "🌙 Local Tarde", "📦 Pasa a Bodega"],
     "Pasa a Bodega": ["☀️ Local Mañana", "🌙 Local Tarde", "🌵 Saltillo"],
 }


### PR DESCRIPTION
### Motivation
- Corregir el comportamiento en la sección "Cambiar Fecha y Turno" de la pestaña `📍 Pedidos Locales` donde no siempre estaban disponibles ambos turnos locales (`☀️ Local Mañana` y `🌙 Local Tarde`) al intentar cambiar el turno de un pedido.

### Description
- Actualicé las opciones de `_LOCAL_TURNOS_CAMBIO_POR_SUBTAB` en `app_a-d.py` para las subtabs `Mañana`, `Tarde` y `Local Día` para incluir `☀️ Local Mañana`, `🌙 Local Tarde`, `🌵 Saltillo` y `📦 Pasa a Bodega` en ese orden.
- Se mantiene la lógica de construcción de opciones en ` _build_turno_options_for_local_change` que prioriza el `current_turno` como opción por defecto al abrir el editor.

### Testing
- Ejecuté `python -m py_compile app_a-d.py` y la comprobación de sintaxis pasó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7ac833f98832691219be3fd5d2194)