### PR TITLE
Agregar opciones de turno Local Mañana/Local Tarde al cambiar tipo de envío

### DIFF
--- a/app_gerente.py
+++ b/app_gerente.py
@@ -5584,7 +5584,13 @@ if "modificar" in tab_map:
                 tipo_envio = st.selectbox("➡️ Cambiar a:", [opcion_contraria])
 
                 if tipo_envio == "📍 Pedido Local":
-                    nuevo_turno = st.selectbox("⏰ Turno", ["🌤️ Local Día", "🌵 Saltillo", "📦 Pasa a Bodega"])
+                    opciones_turno_local = [
+                        "🌞 Local Mañana",
+                        "🌙 Local Tarde",
+                        "🌵 Saltillo",
+                        "📦 Pasa a Bodega",
+                    ]
+                    nuevo_turno = st.selectbox("⏰ Turno", opciones_turno_local)
                     fecha_entrega_actual_raw = str(row.get("Fecha_Entrega", "") or "").strip()
                     fecha_entrega_actual_dt = pd.to_datetime(fecha_entrega_actual_raw, errors="coerce")
                     fecha_entrega_actual_mostrar = (


### PR DESCRIPTION
### Motivation
- Añadir las opciones de turno que faltaban para pedidos locales (Local Mañana y Local Tarde) para que la UI muestre las mismas alternativas que se deben ver y escribir en el Excel. 

### Description
- Reemplacé el selector inline de `Turno` dentro del expander `🚚 Cambio de Tipo de Envío — Ajustar logística` por una lista `opciones_turno_local` que incluye `🌞 Local Mañana` y `🌙 Local Tarde` además de `🌵 Saltillo` y `📦 Pasa a Bodega`.
- El valor seleccionado sigue asignándose a `nuevo_turno` y se persiste usando la misma lógica que actualiza la columna `Turno` en la hoja de cálculo, manteniendo la persistencia sin cambios adicionales.

### Testing
- Ejecuté `python -m py_compile app_gerente.py` y la verificación de sintaxis fue exitosa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7b5abbe4483268d2c8a5ba9a91887)