### PR TITLE
Add Pasa_Bodega report upsert and hooks for order state transitions

### DIFF
--- a/app_a-d.py
+++ b/app_a-d.py
@@ -917,6 +917,109 @@ def _append_local_dia_entry_to_hoja_ruta(row: Any, s3_client_param: Any, origen_
     return True
 
 
+def _is_pasa_bodega_order(row: Any, origen_tab: Any = "") -> bool:
+    """True cuando el pedido corresponde al flujo de subtab Pasa a Bodega."""
+    turno = str(row.get("Turno", "") or "").strip()
+    origen = str(origen_tab or "").strip().lower()
+    return turno == "📦 Pasa a Bodega" or origen in {"pasa a bodega", "📦 pasa a bodega"}
+
+
+def _format_pasa_bodega_date(value: Any) -> str:
+    """Formatea fecha como `DD-Month-YYYY` (ej. 02-January-2026)."""
+    if value is None:
+        return ""
+    if isinstance(value, pd.Timestamp):
+        if pd.isna(value):
+            return ""
+        dt = value.to_pydatetime()
+    else:
+        raw = str(value).strip()
+        if not raw or raw.lower() in {"nat", "nan", "none", "null"}:
+            return ""
+        parsed = pd.to_datetime(raw, errors="coerce")
+        if pd.isna(parsed):
+            return ""
+        dt = parsed.to_pydatetime()
+    return dt.strftime("%d-%B-%Y")
+
+
+def _upsert_pasa_bodega_report_row(row: Any) -> bool:
+    """
+    Crea/actualiza registro en Reportes_Almacen/Pasa_Bodega.
+
+    Clave de actualización: NUMERO DE FACTURA (Folio_Factura).
+    Se ejecuta al procesar y al completar para mantener ESTADO/FECHA QUE PASO A RECOGER actualizados.
+    """
+    reportes_almacen_id = str(
+        st.secrets.get("gsheets", {}).get(
+            "reportes_almacen_sheet_id",
+            st.secrets.get("gsheets", {}).get("reportes_sheet_id", ""),
+        )
+    ).strip()
+    if not reportes_almacen_id:
+        st.error("❌ Falta configurar gsheets.reportes_almacen_sheet_id en secrets.")
+        return False
+
+    folio_factura = _normalize_plain_text(row.get("Folio_Factura", ""))
+    if not folio_factura:
+        st.warning("⚠️ No se pudo registrar en Pasa_Bodega: Folio_Factura vacío.")
+        return False
+
+    payload = {
+        "FECHA DE FACTURA": _format_pasa_bodega_date(row.get("Fecha_Entrega", "")),
+        "NUMERO DE FACTURA": folio_factura,
+        "NOMBRE DE CLIENTE": _normalize_plain_text(row.get("Cliente", "")),
+        "VENDEDOR": _normalize_plain_text(row.get("Vendedor_Registro", "")),
+        "ESTADO": _normalize_plain_text(row.get("Estado", "")),
+        "FECHA QUE PASO A RECOGER": _format_pasa_bodega_date(row.get("Fecha_Completado", "")),
+        "COMENTARIOS": "",
+    }
+
+    try:
+        client = get_gspread_client(_credentials_json_dict=GSHEETS_CREDENTIALS)
+        ws = client.open_by_key(reportes_almacen_id).worksheet("Pasa_Bodega")
+    except Exception as exc:
+        st.error(f"❌ No se pudo abrir Reportes_Almacen/Pasa_Bodega: {exc}")
+        return False
+
+    try:
+        headers = [str(h or "").strip() for h in ws.row_values(1)]
+    except Exception as exc:
+        st.error(f"❌ No se pudieron leer encabezados de Pasa_Bodega: {exc}")
+        return False
+
+    missing = [col for col in payload.keys() if col not in headers]
+    if missing:
+        st.error(f"❌ Faltan columnas en Pasa_Bodega: {', '.join(missing)}")
+        return False
+
+    num_col_idx = headers.index("NUMERO DE FACTURA") + 1
+    target_row = None
+    try:
+        col_values = ws.col_values(num_col_idx)
+        for i, val in enumerate(col_values[1:], start=2):
+            if str(val or "").strip() == folio_factura:
+                target_row = i
+                break
+    except Exception:
+        target_row = None
+
+    row_values = [payload.get(h, "") for h in headers]
+    try:
+        written_row = target_row
+        if target_row:
+            ws.update(f"A{target_row}", [row_values], value_input_option="USER_ENTERED")
+        else:
+            ws.append_row(row_values, value_input_option="USER_ENTERED")
+            written_row = len(ws.col_values(1))
+        if written_row and written_row > 1:
+            ws.format(f"B{written_row}:D{written_row}", {"horizontalAlignment": "CENTER"})
+        return True
+    except Exception as exc:
+        st.error(f"❌ No se pudo actualizar Pasa_Bodega: {exc}")
+        return False
+
+
 def _ensure_visual_state_defaults():
     """Ensure session_state has all UI control keys with safe defaults."""
 
@@ -3440,6 +3543,9 @@ def completar_pedido(
         row["Estado"] = "🟢 Completado"
         row["Fecha_Completado"] = now
 
+    if _is_pasa_bodega_order(row, origen_tab):
+        _upsert_pasa_bodega_report_row(row)
+
     st.session_state["expanded_pedidos"][row["ID_Pedido"]] = True
     st.session_state["expanded_attachments"][row["ID_Pedido"]] = True
 
@@ -3971,6 +4077,9 @@ def mostrar_pedido_detalle(
                             s3_client_param=s3_client_param,
                             origen_tab=origen_tab,
                         )
+
+                    if _is_pasa_bodega_order(row, origen_tab):
+                        _upsert_pasa_bodega_report_row(row)
 
                     st.toast("✅ Pedido marcado como 🔵 En Proceso", icon="✅")
 


### PR DESCRIPTION
### Motivation

- Register and keep updated the "Pasa a Bodega" subtab orders in the central `Reportes_Almacen/Pasa_Bodega` Google Sheet whenever an order is processed or completed. 
- Ensure dates are normalized consistently for the report and avoid creating duplicate rows for the same invoice number.

### Description

- Added `_is_pasa_bodega_order` to detect orders that belong to the "Pasa a Bodega" flow based on `Turno` or `origen_tab` values. 
- Added `_format_pasa_bodega_date` to normalize date values into `DD-Month-YYYY` strings and gracefully handle empty/NaT inputs. 
- Implemented `_upsert_pasa_bodega_report_row` which validates `gsheets` secret, opens `Reportes_Almacen` worksheet `Pasa_Bodega`, verifies required columns, finds an existing row by `NUMERO DE FACTURA` and either updates it or appends a new row, and applies simple formatting; it returns success/failure and surfaces errors via `st.error`. 
- Hooked the upsert into lifecycle events by calling `_upsert_pasa_bodega_report_row(row)` when an order is marked `🔵 En Proceso` and when it is marked `🟢 Completado` inside the existing `mostrar_pedido_detalle` and `completar_pedido` flows. 
- Added user-facing warnings/errors for missing configuration or sheet column mismatches.

### Testing

- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7f2208e70832697303cc4922a6e30)