### PR TITLE
Ignore prefilled 'N.' column and add zebra-striping + include column A in Hoja_Ruta row formatting

### DIFF
--- a/app_a-d.py
+++ b/app_a-d.py
@@ -654,7 +654,9 @@ def _find_next_data_row_in_section(values: list[list[str]], header_row: int) -> 
     n_counter = 1
     for row_idx in range(data_start, data_end + 1):
         row = values[row_idx - 1] if row_idx - 1 < len(values) else []
-        used = any(_normalize_plain_text(c) for c in row[:10])
+        # La columna A ("N.") viene prellenada con 1..13 por plantilla; no debe
+        # contar como fila ocupada. Solo evaluamos columnas de captura B:J.
+        used = any(_normalize_plain_text(c) for c in row[1:10])
         if not used:
             return row_idx, n_counter
         n_counter += 1
@@ -827,18 +829,20 @@ def _format_hoja_ruta_new_section(ws: Any, title_row: int, header_row: int) -> N
     )
 
 
-def _format_hoja_ruta_data_row(ws: Any, row_number: int) -> None:
-    """Formato de contenido: B:J Calibri 28 no bold."""
+def _format_hoja_ruta_data_row(ws: Any, row_number: int, n_value: int) -> None:
+    """Formato de contenido A:J Calibri 28 + zebra (impar gris, par blanco)."""
+    is_odd = int(n_value) % 2 == 1
+    row_bg = {"red": 0.90, "green": 0.90, "blue": 0.90} if is_odd else {"red": 1.0, "green": 1.0, "blue": 1.0}
     _set_range_format(
         ws,
         row_start=row_number,
         row_end=row_number,
-        col_start=2,
+        col_start=1,
         col_end=10,
         font_family="Calibri",
         font_size=28,
         bold=False,
-        bg_color=None,
+        bg_color=row_bg,
     )
 
 
@@ -951,7 +955,7 @@ def _append_local_dia_entry_to_hoja_ruta(row: Any, s3_client_param: Any, origen_
         entry["firma"],
     ]
     _write_row_values(ws, target_row, row_values)
-    _format_hoja_ruta_data_row(ws, row_number=target_row)
+    _format_hoja_ruta_data_row(ws, row_number=target_row, n_value=n_value)
     return True
 
 


### PR DESCRIPTION
### Motivation

- The template pre-fills the "N." column (A) with 1..13 which caused rows to be treated as occupied when they are actually empty, and the data rows needed consistent formatting including that column and visual zebra-striping for readability.

### Description

- Updated `_find_next_data_row_in_section` to ignore the prefilled column A when detecting an occupied row by checking columns B:J (`row[1:10]`).
- Changed `_format_hoja_ruta_data_row` signature to accept `n_value` and compute an odd/even zebra background color, and expanded formatting to cover columns A:J (`col_start=1`) with the calculated `bg_color`.
- Updated the call site in `_append_local_dia_entry_to_hoja_ruta` to pass the discovered `n_value` into `_format_hoja_ruta_data_row`.

### Testing

- Ran the test suite with `pytest -q` and the relevant tests for hoja_ruta functions passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e94eeddcc483268043bb6afd4fce88)