### PR TITLE
Organizador: agregar check de facturas con normalización de folios y detección de columnas

### DIFF
--- a/app_gerente.py
+++ b/app_gerente.py
@@ -1359,6 +1359,33 @@ def normalizar_folio(texto):
     return limpio_sin_espacios.upper()
 
 
+def normalizar_folio_para_match(texto):
+    """Normaliza folios para comparar aunque vengan con/sin prefijo F."""
+    base = normalizar_folio(texto)
+    if not base:
+        return ""
+    solo_digitos = "".join(re.findall(r"\d+", base))
+    if solo_digitos:
+        return solo_digitos
+    return re.sub(r"[^A-Z0-9]", "", base)
+
+
+def encontrar_columna_por_alias(df: pd.DataFrame, aliases: list[str]) -> str | None:
+    """Busca una columna por nombre, ignorando acentos, espacios y mayúsculas."""
+    if df.empty:
+        return None
+
+    def _norm_col(valor: str) -> str:
+        txt = normalizar(str(valor or ""))
+        return re.sub(r"[^a-z0-9]", "", txt)
+
+    alias_norm = {_norm_col(a) for a in aliases}
+    for col in df.columns:
+        if _norm_col(col) in alias_norm:
+            return col
+    return None
+
+
 def tokenizar_texto(texto):
     """Divide texto normalizado en tokens alfanuméricos (sin importar el orden)."""
     texto_norm = normalizar(str(texto or "").strip())
@@ -5684,6 +5711,7 @@ if "organizador" in tab_map:
 
         # --- Subpestañas internas del organizador ---
         organizer_tab_specs = [
+            ("check_facturas", "🧾 Check de Facturas"),
             ("casos_especiales", "🛡️ Casos especiales"),
             ("hoy", "📌 Hoy"),
             ("agenda", "🗓️ Agenda"),
@@ -5734,6 +5762,216 @@ if "organizador" in tab_map:
 
         if errores_alejandro:
             st.warning("⚠️ Hay errores leyendo alejandro_data. Revisa los logs o ejecuta diagnóstico en modo mantenimiento.")
+
+        with sub_map["check_facturas"]:
+            st.subheader("🧾 Check de Facturas")
+            st.caption(
+                "Sube un archivo con encabezados en la fila 3 (Vendedor, FolioSerie, Cliente, Fecha) "
+                "para detectar qué facturas no existen en datos_pedidos/data_pedidos."
+            )
+
+            archivo_facturas = st.file_uploader(
+                "Archivo de facturas (Excel o CSV)",
+                type=["xlsx", "xls", "csv"],
+                key="organizador_check_facturas_archivo",
+            )
+
+            if archivo_facturas is not None:
+                try:
+                    nombre_archivo = archivo_facturas.name.lower()
+                    if nombre_archivo.endswith(".csv"):
+                        df_facturas = pd.read_csv(archivo_facturas, header=2)
+                    else:
+                        df_facturas = pd.read_excel(archivo_facturas, header=2)
+                except Exception as e:
+                    st.error(f"❌ No se pudo leer el archivo: {e}")
+                    df_facturas = pd.DataFrame()
+
+                if not df_facturas.empty:
+                    col_vendedor = encontrar_columna_por_alias(df_facturas, ["Vendedor"])
+                    col_folio = encontrar_columna_por_alias(df_facturas, ["FolioSerie", "Folio", "Folio_Serie"])
+                    col_cliente = encontrar_columna_por_alias(df_facturas, ["Cliente"])
+                    col_fecha = encontrar_columna_por_alias(df_facturas, ["Fecha", "FechaFactura"])
+
+                    faltantes = []
+                    if col_vendedor is None:
+                        faltantes.append("Vendedor")
+                    if col_folio is None:
+                        faltantes.append("FolioSerie")
+                    if col_cliente is None:
+                        faltantes.append("Cliente")
+                    if col_fecha is None:
+                        faltantes.append("Fecha")
+
+                    if faltantes:
+                        st.error(f"❌ No se encontraron columnas requeridas en fila 3: {', '.join(faltantes)}")
+                    else:
+                        df_facturas = df_facturas[[col_vendedor, col_folio, col_cliente, col_fecha]].copy()
+                        df_facturas.columns = ["Vendedor", "FolioSerie", "Cliente", "Fecha"]
+                        df_facturas["FolioSerie"] = df_facturas["FolioSerie"].astype(str).str.strip()
+                        df_facturas = df_facturas[df_facturas["FolioSerie"] != ""].copy()
+                        df_facturas["_folio_match"] = df_facturas["FolioSerie"].apply(normalizar_folio_para_match)
+                        df_facturas = df_facturas[df_facturas["_folio_match"] != ""].copy()
+                        ahora_cdmx = now_cdmx()
+                        ahora_naive = ahora_cdmx.replace(tzinfo=None)
+                        limite_72h = ahora_naive - timedelta(hours=72)
+
+                        df_facturas["_fecha_factura_dt"] = pd.to_datetime(
+                            df_facturas["Fecha"], errors="coerce", dayfirst=True
+                        )
+                        df_facturas = df_facturas[df_facturas["_fecha_factura_dt"].notna()].copy()
+                        df_facturas = df_facturas[
+                            (df_facturas["_fecha_factura_dt"] >= limite_72h)
+                            & (df_facturas["_fecha_factura_dt"] <= ahora_naive)
+                        ].copy()
+                        if df_facturas.empty:
+                            st.info(
+                                "No hay filas en el archivo dentro de las últimas 72 horas según la columna Fecha "
+                                f"({limite_72h.strftime('%d/%m/%Y %H:%M')} a {ahora_naive.strftime('%d/%m/%Y %H:%M')})."
+                            )
+
+                        df_pedidos_match = cargar_pedidos().copy()
+                        if "Folio_Factura" not in df_pedidos_match.columns:
+                            df_pedidos_match["Folio_Factura"] = ""
+                        df_pedidos_match["_folio_match"] = df_pedidos_match["Folio_Factura"].apply(normalizar_folio_para_match)
+                        col_hora_registro = encontrar_columna_por_alias(
+                            df_pedidos_match,
+                            ["Hora_Registro", "Fecha_Hora_Registro", "Fecha_Registro", "Created_At"],
+                        )
+                        if col_hora_registro is None:
+                            df_pedidos_match["_hora_registro_dt"] = pd.NaT
+                        else:
+                            df_pedidos_match["_hora_registro_dt"] = pd.to_datetime(
+                                df_pedidos_match[col_hora_registro], errors="coerce"
+                            )
+
+                        col_cliente_sistema = encontrar_columna_por_alias(
+                            df_pedidos_match,
+                            ["Cliente", "Nombre_Cliente", "NombreCliente", "Razon_Social", "Razón Social"],
+                        )
+                        if col_cliente_sistema is None:
+                            df_pedidos_match["_cliente_norm"] = ""
+                        else:
+                            df_pedidos_match["_cliente_norm"] = (
+                                df_pedidos_match[col_cliente_sistema]
+                                .astype(str)
+                                .apply(normalizar)
+                                .str.strip()
+                            )
+                        clientes_sistema_norm = [
+                            c for c in df_pedidos_match["_cliente_norm"].dropna().astype(str).tolist() if c
+                        ]
+                        df_facturas["_cliente_norm"] = df_facturas["Cliente"].astype(str).apply(normalizar).str.strip()
+                        validos_por_folio = []
+                        validos_por_cliente = []
+
+                        for _, fila_factura in df_facturas.iterrows():
+                            fecha_factura = fila_factura.get("_fecha_factura_dt")
+                            folio_factura = fila_factura.get("_folio_match", "")
+                            cliente_factura = fila_factura.get("_cliente_norm", "")
+                            ventana_fin = fecha_factura + timedelta(hours=72)
+
+                            candidatos_folio = df_pedidos_match[
+                                df_pedidos_match["_folio_match"].astype(str).str.strip() == str(folio_factura).strip()
+                            ].copy()
+                            match_folio_con_fecha = (
+                                (not candidatos_folio.empty)
+                                and candidatos_folio["_hora_registro_dt"].between(fecha_factura, ventana_fin).any()
+                            )
+
+                            candidatos_cliente = df_pedidos_match.iloc[0:0].copy()
+                            if cliente_factura:
+                                candidatos_cliente = df_pedidos_match[
+                                    df_pedidos_match["_cliente_norm"].astype(str).apply(
+                                        lambda c: coincide_nombre_cliente(cliente_factura, c)
+                                    )
+                                ].copy()
+                            match_cliente_con_fecha = (
+                                (not candidatos_cliente.empty)
+                                and candidatos_cliente["_hora_registro_dt"].between(fecha_factura, ventana_fin).any()
+                            )
+
+                            validos_por_folio.append(bool(match_folio_con_fecha))
+                            validos_por_cliente.append(bool(match_cliente_con_fecha and not match_folio_con_fecha))
+
+                        df_facturas["_match_valido_folio"] = validos_por_folio
+                        df_facturas["_match_valido_cliente_sin_folio"] = validos_por_cliente
+
+                        df_no_encontradas = (
+                            df_facturas[
+                                ~(
+                                    df_facturas["_match_valido_folio"]
+                                    | df_facturas["_match_valido_cliente_sin_folio"]
+                                )
+                            ]
+                            .drop(
+                                columns=[
+                                    "_folio_match",
+                                    "_fecha_factura_dt",
+                                    "_cliente_norm",
+                                    "_match_valido_folio",
+                                    "_match_valido_cliente_sin_folio",
+                                ],
+                                errors="ignore",
+                            )
+                            .drop_duplicates()
+                            .reset_index(drop=True)
+                        )
+
+                        df_match_cliente_sin_folio = (
+                            df_facturas[df_facturas["_match_valido_cliente_sin_folio"]]
+                            .drop(
+                                columns=[
+                                    "_folio_match",
+                                    "_fecha_factura_dt",
+                                    "_cliente_norm",
+                                    "_match_valido_folio",
+                                    "_match_valido_cliente_sin_folio",
+                                ],
+                                errors="ignore",
+                            )
+                            .drop_duplicates()
+                            .reset_index(drop=True)
+                        )
+
+                        total_archivo = int(len(df_facturas))
+                        total_no_encontradas = int(len(df_no_encontradas))
+                        st.info(
+                            f"Facturas analizadas: {total_archivo} | "
+                            f"No encontradas en sistema: {total_no_encontradas}"
+                        )
+                        st.caption(
+                            f"Filtro aplicado: últimas 72 horas ({limite_72h.strftime('%d/%m/%Y %H:%M')} "
+                            f"a {ahora_naive.strftime('%d/%m/%Y %H:%M')}). "
+                            "Regla de validación: Hora_Registro debe estar entre Fecha factura y +72h."
+                        )
+
+                        if total_archivo == 0:
+                            st.info("No hay facturas en las últimas 72 horas para validar en el archivo.")
+                        elif total_no_encontradas == 0:
+                            st.success(
+                                "✅ Todas las facturas (últimas 72h) cumplen match válido por folio o por cliente "
+                                "y con ventana de fecha lógica."
+                            )
+                        else:
+                            st.warning(
+                                "⚠️ Estas facturas (últimas 72h) no tienen match válido en data_pedidos/datos_pedidos "
+                                "considerando folio/cliente + regla de fecha:"
+                            )
+                            st.dataframe(df_no_encontradas, use_container_width=True)
+                            st.download_button(
+                                "⬇️ Descargar faltantes (CSV)",
+                                data=df_no_encontradas.to_csv(index=False).encode("utf-8-sig"),
+                                file_name="facturas_no_encontradas.csv",
+                                mime="text/csv",
+                                key="organizador_check_facturas_descargar_csv",
+                            )
+
+                        if not df_match_cliente_sin_folio.empty:
+                            st.info(
+                                "ℹ️ Coincidencias por cliente (sin folio), válidas por fecha (Fecha factura -> +72h):"
+                            )
+                            st.dataframe(df_match_cliente_sin_folio, use_container_width=True)
 
         with sub_map["hoy"]:
             st.subheader("📌 Hoy")


### PR DESCRIPTION
### Motivation

- Añadir una herramienta en el organizador para detectar facturas recientes que no estén registradas en `data_pedidos` usando folio o cliente y una ventana temporal de validación de 72 horas.
- Mejorar la robustez de lectura y comparación de columnas al aceptar variantes de encabezados y normalizar folios con/sin prefijo.

### Description

- Se añadió la función `normalizar_folio_para_match` para obtener una forma comparable del folio (extrae solo dígitos cuando procede, y limpia caracteres alfanuméricos en otros casos). 
- Se añadió la función `encontrar_columna_por_alias` que busca columnas en un `DataFrame` ignorando acentos, espacios y mayúsculas para mapear diferentes encabezados (aliases).
- Se incorporó una nueva pestaña `🧾 Check de Facturas` al panel `organizador` con un `file_uploader` que acepta `xlsx`, `xls` o `csv`, lee la hoja (encabezados en fila 3), normaliza columnas y filtra filas dentro de las últimas 72 horas.
- Se implementó la lógica de matching entre el archivo de facturas y `data_pedidos`: normalización de folios, normalización de nombres de cliente, comparación por folio y por cliente dentro de una ventana de fecha (Fecha factura -> +72h), y presentación de resultados con posibilidad de descargar los faltantes en CSV.

### Testing

- No se añadieron ni ejecutaron pruebas automatizadas como parte de este cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaafd8969883269ce0ab18acfe3d51)