### PR TITLE
Agregar checkbox 'Enterado' para comentarios y bloquear `Procesar` hasta confirmación

### DIFF
--- a/app_a-d.py
+++ b/app_a-d.py
@@ -4103,17 +4103,20 @@ def mostrar_pedido_detalle(
     gsheet_row_index,
     col_print_btn,
     s3_client_param,
+    comentario_enterado_ok=True,
 ):
     """Procesa el pedido: actualiza estado a 'En Proceso' sin alterar UI."""
 
     estado_actual_ui = str(row.get("Estado", "")).strip()
     puede_procesar_ui = estado_actual_ui in ["🟡 Pendiente", "🔴 Demorado"]
 
+    boton_procesar_habilitado = puede_procesar_ui and comentario_enterado_ok
+
     if col_print_btn.button(
         "⚙️ Procesar",
         key=f"procesar_{row['ID_Pedido']}_{origen_tab}",
         on_click=_mark_skip_demorado_check_once,
-        disabled=not puede_procesar_ui,
+        disabled=not boton_procesar_habilitado,
     ):
         # Solo para marcar que ya se presionó (si se usa para estilos/toasts)
         st.session_state.setdefault("printed_items", {})
@@ -4471,9 +4474,18 @@ def mostrar_pedido(df, idx, row, orden, origen_tab, current_main_tab_label, work
         col_order_num, col_client, col_time, col_status, col_vendedor, col_print_btn, col_complete_btn = st.columns([0.5, 2, 1.5, 1, 1.2, 1, 1])
         # --- Mostrar Comentario (si existe)
         comentario = str(row.get("Comentario", "")).strip()
+        comentario_enterado_ok = True
         if comentario:
             st.markdown("##### 📝 Comentario del Pedido")
             st.info(comentario)
+            enterado_key = f"enterado_comentario_{row['ID_Pedido']}"
+            comentario_enterado_ok = st.checkbox(
+                "✅ Enterado",
+                key=enterado_key,
+                help="Marca esta casilla para confirmar que leíste el comentario antes de procesar el pedido.",
+            )
+            if not comentario_enterado_ok and row.get("Estado") in ["🟡 Pendiente", "🔴 Demorado"]:
+                st.caption("⚠️ Debes marcar **Enterado** para habilitar el botón **⚙️ Procesar**.")
 
         if es_local_no_entregado:
             estado_entrega_valor = str(row.get("Estado_Entrega", "")).strip()
@@ -4524,6 +4536,7 @@ def mostrar_pedido(df, idx, row, orden, origen_tab, current_main_tab_label, work
                 gsheet_row_index,
                 col_print_btn,
                 s3_client_param,
+                comentario_enterado_ok=comentario_enterado_ok,
             )
         else:
             col_print_btn.write("")


### PR DESCRIPTION
### Motivation
- Evitar que un pedido en estado `🟡 Pendiente`/`🔴 Demorado` sea procesado si contiene texto en la columna `Comentario` y el usuario no confirma que lo leyó.

### Description
- Se añadió un checkbox `✅ Enterado` que se muestra cuando `Comentario` tiene contenido y muestra el texto del comentario con `st.info`.
- El botón `⚙️ Procesar` ahora se habilita condicionalmente según el estado del pedido y el valor de `comentario_enterado_ok` (nuevo parámetro en `mostrar_pedido_detalle`).
- Se pasó el flag `comentario_enterado_ok` desde `mostrar_pedido(...)` hacia `mostrar_pedido_detalle(...)` para conectar la UI del comentario con la lógica de procesamiento.
- Se agregó una leyenda (`st.caption`) que explica por qué el botón está deshabilitado cuando no se ha marcado `Enterado`.

### Testing
- Se ejecutó la compilación sintáctica con `python -m py_compile app_a-d.py` y finalizó correctamente (sin errores de sintaxis).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebb05a4ba083269d8e7f09e6e129fd)