### PR TITLE
Require 'Enterado' checkbox to enable processing, preserve UI context, and add comment/guide markers

### DIFF
--- a/app_a-d.py
+++ b/app_a-d.py
@@ -3560,6 +3560,14 @@ def _preserve_and_mark_skip_demorado() -> None:
     _mark_skip_demorado_check_once()
 
 
+def _on_comentario_enterado_change(row_id: str, origen_tab: str) -> None:
+    """Preserva contexto visual al marcar/desmarcar Enterado en comentarios."""
+
+    _mark_skip_demorado_check_once()
+    preserve_tab_state()
+    marcar_contexto_pedido(row_id, origen_tab, scroll=False)
+
+
 def completar_pedido(
     df: pd.DataFrame,
     idx: int,
@@ -4103,17 +4111,20 @@ def mostrar_pedido_detalle(
     gsheet_row_index,
     col_print_btn,
     s3_client_param,
+    comentario_enterado_ok=True,
 ):
     """Procesa el pedido: actualiza estado a 'En Proceso' sin alterar UI."""
 
     estado_actual_ui = str(row.get("Estado", "")).strip()
     puede_procesar_ui = estado_actual_ui in ["🟡 Pendiente", "🔴 Demorado"]
 
+    boton_procesar_habilitado = puede_procesar_ui and comentario_enterado_ok
+
     if col_print_btn.button(
         "⚙️ Procesar",
         key=f"procesar_{row['ID_Pedido']}_{origen_tab}",
         on_click=_mark_skip_demorado_check_once,
-        disabled=not puede_procesar_ui,
+        disabled=not boton_procesar_habilitado,
     ):
         # Solo para marcar que ya se presionó (si se usa para estilos/toasts)
         st.session_state.setdefault("printed_items", {})
@@ -4241,10 +4252,16 @@ def mostrar_pedido(df, idx, row, orden, origen_tab, current_main_tab_label, work
     pago_confirmado = _estado_pago_es_pagado(estado_pago_actual)
     pago_badge = "✅ Pagado" if pago_confirmado else "🔴 No Pagado"
     is_local_main_tab = es_main_tab_pedidos_locales(current_main_tab_label)
-    guia_marker = "📋 " if (not is_local_main_tab and pedido_sin_guia(row)) else ""
+    es_foraneo_contexto = (
+        str(origen_tab).strip() == "Foráneo"
+        or str(row.get("Tipo_Envio", "")).strip() == "🚚 Pedido Foráneo"
+    )
+    guia_marker = "📋 " if (es_foraneo_contexto and pedido_requiere_guia(row)) else ""
+    comentario_resumen = str(row.get("Comentario", "")).strip()
+    comentario_marker = "💬 " if comentario_resumen else ""
     st.markdown(f'<a name="pedido_{row["ID_Pedido"]}"></a>', unsafe_allow_html=True)
     _render_bulk_selector(row)
-    titulo_expander = f"{guia_marker}{row['Estado']} - {folio} - {row['Cliente']}"
+    titulo_expander = f"{guia_marker}{comentario_marker}{row['Estado']} - {folio} - {row['Cliente']}"
     if es_local_bodega:
         titulo_expander = f"{titulo_expander} | Estado de pago: {pago_badge}"
 
@@ -4470,10 +4487,21 @@ def mostrar_pedido(df, idx, row, orden, origen_tab, current_main_tab_label, work
 
         col_order_num, col_client, col_time, col_status, col_vendedor, col_print_btn, col_complete_btn = st.columns([0.5, 2, 1.5, 1, 1.2, 1, 1])
         # --- Mostrar Comentario (si existe)
-        comentario = str(row.get("Comentario", "")).strip()
+        comentario = comentario_resumen
+        comentario_enterado_ok = True
         if comentario:
-            st.markdown("##### 📝 Comentario del Pedido")
+            st.markdown("##### 💬 Comentario del Pedido")
             st.info(comentario)
+            enterado_key = f"enterado_comentario_{row['ID_Pedido']}"
+            comentario_enterado_ok = st.checkbox(
+                "✅ Enterado",
+                key=enterado_key,
+                help="Marca esta casilla para confirmar que leíste el comentario antes de procesar el pedido.",
+                on_change=_on_comentario_enterado_change,
+                args=(row["ID_Pedido"], origen_tab),
+            )
+            if not comentario_enterado_ok and row.get("Estado") in ["🟡 Pendiente", "🔴 Demorado"]:
+                st.caption("⚠️ Debes marcar **Enterado** para habilitar el botón **⚙️ Procesar**.")
 
         if es_local_no_entregado:
             estado_entrega_valor = str(row.get("Estado_Entrega", "")).strip()
@@ -4524,6 +4552,7 @@ def mostrar_pedido(df, idx, row, orden, origen_tab, current_main_tab_label, work
                 gsheet_row_index,
                 col_print_btn,
                 s3_client_param,
+                comentario_enterado_ok=comentario_enterado_ok,
             )
         else:
             col_print_btn.write("")


### PR DESCRIPTION
### Motivation
- Prevent accidental processing of orders without first acknowledging important per-order comments by requiring a confirmation checkbox. 
- Preserve visual/tab context and avoid immediate auto-transition to `Demorado` after manual interactions, and improve visual markers for comments and foráneo guides. 

### Description
- Added `_on_comentario_enterado_change` which calls `preserve_tab_state`, `_mark_skip_demorado_check_once`, and `marcar_contexto_pedido(row_id, origen_tab, scroll=False)` to preserve UI context when the "Enterado" checkbox changes. 
- Render a comment marker and include a `💬` comment section using `comentario_resumen`, add an `Enterado` checkbox (`enterado_comentario_{ID_Pedido}`) that passes its state as `comentario_enterado_ok` to `mostrar_pedido_detalle`, and show a caption warning if not checked while the order is `🟡 Pendiente` or `🔴 Demorado`. 
- Make the `Procesar` button respect the comment acknowledgement by computing `boton_procesar_habilitado = puede_procesar_ui and comentario_enterado_ok`, and update guide/title markers by computing `es_foraneo_contexto` and using `pedido_requiere_guia(row)` to set the `📋` marker and adding a `💬` marker to the expander title. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebb05a4ba083269d8e7f09e6e129fd)