### PR TITLE
Require 'Enterado' checkbox to enable Procesar and improve guia/comment markers; preserve UI state on acknowledge

### DIFF
--- a/app_a-d.py
+++ b/app_a-d.py
@@ -3560,6 +3560,14 @@ def _preserve_and_mark_skip_demorado() -> None:
     _mark_skip_demorado_check_once()
 
 
+def _on_comentario_enterado_change(row_id: str, origen_tab: str) -> None:
+    """Preserva contexto visual al marcar/desmarcar Enterado en comentarios."""
+
+    _mark_skip_demorado_check_once()
+    preserve_tab_state()
+    marcar_contexto_pedido(row_id, origen_tab, scroll=False)
+
+
 def completar_pedido(
     df: pd.DataFrame,
     idx: int,
@@ -4103,17 +4111,20 @@ def mostrar_pedido_detalle(
     gsheet_row_index,
     col_print_btn,
     s3_client_param,
+    comentario_enterado_ok=True,
 ):
     """Procesa el pedido: actualiza estado a 'En Proceso' sin alterar UI."""
 
     estado_actual_ui = str(row.get("Estado", "")).strip()
     puede_procesar_ui = estado_actual_ui in ["🟡 Pendiente", "🔴 Demorado"]
 
+    boton_procesar_habilitado = puede_procesar_ui and comentario_enterado_ok
+
     if col_print_btn.button(
         "⚙️ Procesar",
         key=f"procesar_{row['ID_Pedido']}_{origen_tab}",
         on_click=_mark_skip_demorado_check_once,
-        disabled=not puede_procesar_ui,
+        disabled=not boton_procesar_habilitado,
     ):
         # Solo para marcar que ya se presionó (si se usa para estilos/toasts)
         st.session_state.setdefault("printed_items", {})
@@ -4241,10 +4252,22 @@ def mostrar_pedido(df, idx, row, orden, origen_tab, current_main_tab_label, work
     pago_confirmado = _estado_pago_es_pagado(estado_pago_actual)
     pago_badge = "✅ Pagado" if pago_confirmado else "🔴 No Pagado"
     is_local_main_tab = es_main_tab_pedidos_locales(current_main_tab_label)
-    guia_marker = "📋 " if (not is_local_main_tab and pedido_sin_guia(row)) else ""
+    es_foraneo_contexto = (
+        str(origen_tab).strip() == "Foráneo"
+        or str(row.get("Tipo_Envio", "")).strip() == "🚚 Pedido Foráneo"
+    )
+    guia_marker = "📋 " if (
+        es_foraneo_contexto
+        and pedido_requiere_guia(row)
+        and (not pedido_tiene_guia_adjunta(row))
+    ) else ""
+    comentario_resumen = str(row.get("Comentario", "")).strip()
+    enterado_key = f"enterado_comentario_{row['ID_Pedido']}"
+    comentario_enterado_actual = bool(st.session_state.get(enterado_key, False))
+    comentario_marker = "💬 " if (comentario_resumen and not comentario_enterado_actual) else ""
     st.markdown(f'<a name="pedido_{row["ID_Pedido"]}"></a>', unsafe_allow_html=True)
     _render_bulk_selector(row)
-    titulo_expander = f"{guia_marker}{row['Estado']} - {folio} - {row['Cliente']}"
+    titulo_expander = f"{guia_marker}{comentario_marker}{row['Estado']} - {folio} - {row['Cliente']}"
     if es_local_bodega:
         titulo_expander = f"{titulo_expander} | Estado de pago: {pago_badge}"
 
@@ -4470,10 +4493,20 @@ def mostrar_pedido(df, idx, row, orden, origen_tab, current_main_tab_label, work
 
         col_order_num, col_client, col_time, col_status, col_vendedor, col_print_btn, col_complete_btn = st.columns([0.5, 2, 1.5, 1, 1.2, 1, 1])
         # --- Mostrar Comentario (si existe)
-        comentario = str(row.get("Comentario", "")).strip()
+        comentario = comentario_resumen
+        comentario_enterado_ok = True
         if comentario:
-            st.markdown("##### 📝 Comentario del Pedido")
+            st.markdown("##### 💬 Comentario del Pedido")
             st.info(comentario)
+            comentario_enterado_ok = st.checkbox(
+                "✅ Enterado",
+                key=enterado_key,
+                help="Marca esta casilla para confirmar que leíste el comentario antes de procesar el pedido.",
+                on_change=_on_comentario_enterado_change,
+                args=(row["ID_Pedido"], origen_tab),
+            )
+            if not comentario_enterado_ok and row.get("Estado") in ["🟡 Pendiente", "🔴 Demorado"]:
+                st.caption("⚠️ Debes marcar **Enterado** para habilitar el botón **⚙️ Procesar**.")
 
         if es_local_no_entregado:
             estado_entrega_valor = str(row.get("Estado_Entrega", "")).strip()
@@ -4524,6 +4557,7 @@ def mostrar_pedido(df, idx, row, orden, origen_tab, current_main_tab_label, work
                 gsheet_row_index,
                 col_print_btn,
                 s3_client_param,
+                comentario_enterado_ok=comentario_enterado_ok,
             )
         else:
             col_print_btn.write("")


### PR DESCRIPTION
### Motivation

- Prevent accidental processing of orders with important comments by requiring explicit acknowledgement before enabling `Procesar`.
- Improve visual markers for missing guides and unread comments and preserve UI context when a comment is acknowledged.

### Description

- Added `_on_comentario_enterado_change` to preserve tab state and mark `skip_demorado_check_once` when a comment is acknowledged. 
- Added comment-awareness to `mostrar_pedido` by computing `comentario_resumen`, `enterado_key`, `comentario_enterado_ok`, and a `comentario_marker` that is prepended to the order title when unread. 
- Show a `✅ Enterado` checkbox in the comment block that controls a new `comentario_enterado_ok` flag and calls `_on_comentario_enterado_change` via `on_change`. 
- Propagated `comentario_enterado_ok` into `mostrar_pedido_detalle` and disable the `Procesar` button unless the order is in a processable state and the comment has been acknowledged. 
- Refined guide marker logic to detect foráneo context and require `pedido_requiere_guia` and absence of attached guide via `pedido_tiene_guia_adjunta` before adding the `📋` marker. 

### Testing

- Ran the project's automated unit test suite with `pytest` and all tests passed. 
- Ran automated linters/static checks and they completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebb05a4ba083269d8e7f09e6e129fd)