### PR TITLE
Evita reasignar números foráneos ya usados en casos

### DIFF
--- a/app_a-d.py
+++ b/app_a-d.py
@@ -1877,6 +1877,38 @@ def _parse_foraneo_number(raw: Any) -> Optional[int]:
     return value if value > 0 else None
 
 
+def _get_next_foraneo_number(
+    worksheet_casos: Any,
+    headers_casos: list[str],
+    flow_map_foraneo: Optional[dict[str, str]] = None,
+) -> str:
+    """Calcula el siguiente número foráneo libre usando mapa de flujo + hoja actual."""
+    used_numbers: set[int] = set()
+
+    for val in (flow_map_foraneo or {}).values():
+        parsed = _parse_foraneo_number(val)
+        if parsed is not None:
+            used_numbers.add(parsed)
+
+    if worksheet_casos is not None and "Numero_Foraneo" in headers_casos:
+        try:
+            col_idx = headers_casos.index("Numero_Foraneo") + 1
+            values = worksheet_casos.col_values(col_idx)
+        except Exception:
+            values = []
+
+        for raw in values[1:]:
+            parsed = _parse_foraneo_number(raw)
+            if parsed is not None:
+                used_numbers.add(parsed)
+
+    next_number = 1
+    while next_number in used_numbers:
+        next_number += 1
+
+    return f"{next_number:02d}"
+
+
 def _parse_row_sort_datetime(row: pd.Series) -> pd.Timestamp:
     """Replica el sort_key operativo de app_i para numeración foránea."""
 
@@ -7485,12 +7517,11 @@ if df_main is not None:
                     assign_col, info_col = st.columns([1, 2])
                     with assign_col:
                         if st.button("Asignar número foráneo", key=f"assign_num_foraneo_{row_key}"):
-                            max_actual = 0
-                            for val in st.session_state.get("flow_number_map_foraneo", {}).values():
-                                parsed = _parse_foraneo_number(val)
-                                if parsed and parsed > max_actual:
-                                    max_actual = parsed
-                            siguiente = f"{max_actual + 1:02d}"
+                            siguiente = _get_next_foraneo_number(
+                                worksheet_casos=worksheet_casos,
+                                headers_casos=headers_casos,
+                                flow_map_foraneo=st.session_state.get("flow_number_map_foraneo", {}),
+                            )
 
                             try:
                                 row_idx_int = int(float(row_idx_case)) if row_idx_case is not None and not pd.isna(row_idx_case) else None
@@ -8201,12 +8232,11 @@ if df_main is not None:
                     assign_col, info_col = st.columns([1, 2])
                     with assign_col:
                         if st.button("Asignar número foráneo", key=f"assign_num_foraneo_g_{unique_suffix}"):
-                            max_actual = 0
-                            for val in st.session_state.get("flow_number_map_foraneo", {}).values():
-                                parsed = _parse_foraneo_number(val)
-                                if parsed and parsed > max_actual:
-                                    max_actual = parsed
-                            siguiente = f"{max_actual + 1:02d}"
+                            siguiente = _get_next_foraneo_number(
+                                worksheet_casos=worksheet_casos,
+                                headers_casos=headers_casos,
+                                flow_map_foraneo=st.session_state.get("flow_number_map_foraneo", {}),
+                            )
 
                             try:
                                 row_idx_int = int(float(row_idx_case)) if row_idx_case is not None and not pd.isna(row_idx_case) else None


### PR DESCRIPTION
### Motivation
- Evitar que el botón "Asignar número foráneo" asigne un número ya usado cuando la sesión local no está sincronizada con la hoja `casos_especiales` y otro frente ya guardó un número.

### Description
- Agregué la función `_get_next_foraneo_number(worksheet_casos, headers_casos, flow_map_foraneo)` que calcula el siguiente número libre combinando los números en `flow_number_map_foraneo` y los valores reales leídos de la columna `Numero_Foraneo` en la hoja.
- Reemplacé la lógica previa de `max + 1` en los botones de asignación de números (Devoluciones y Garantías) para usar `_get_next_foraneo_number` antes de guardar.
- La nueva función maneja errores al leer la columna y normaliza/parsea valores con `_parse_foraneo_number` para evitar colisiones por formato.

### Testing
- Ejecuté `python -m py_compile app_a-d.py` y la compilación fue exitosa.
- Verifiqué que la nueva función se invoca desde ambos puntos de asignación y que el archivo pasa la comprobación de sintaxis.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef839c0b648326a8f39f15252cfbfc)