### PR TITLE
Compute next `Numero_Foraneo` globally and prefer manual sheet value for foráneo cases

### DIFF
--- a/app_a-d.py
+++ b/app_a-d.py
@@ -1821,7 +1821,11 @@ def _normalize_text_for_matching(text: str) -> str:
 
 def _is_exact_pedido_foraneo(tipo_envio: Any) -> bool:
     """True solo para el literal de negocio '🚚 Pedido Foráneo' (normalizado)."""
-    return _normalize_text_for_matching(str(tipo_envio)) == "🚚 pedido foraneo"
+    tipo_norm = _normalize_text_for_matching(str(tipo_envio or ""))
+    # Permite variantes visuales del mismo literal (emoji/prefijos),
+    # sin confundir otros tipos de envío que solo contienen "foraneo".
+    tipo_norm = re.sub(r"^[^a-z0-9]+", "", tipo_norm)
+    return tipo_norm == "pedido foraneo"
 
 
 def _flow_key(value: Any) -> str:
@@ -1875,6 +1879,38 @@ def _parse_foraneo_number(raw: Any) -> Optional[int]:
     except ValueError:
         return None
     return value if value > 0 else None
+
+
+def _get_next_foraneo_number(
+    worksheet_casos: Any,
+    headers_casos: list[str],
+    flow_map_foraneo: Optional[dict[str, str]] = None,
+) -> str:
+    """Calcula el siguiente número foráneo libre usando mapa de flujo + hoja actual."""
+    used_numbers: set[int] = set()
+
+    for val in (flow_map_foraneo or {}).values():
+        parsed = _parse_foraneo_number(val)
+        if parsed is not None:
+            used_numbers.add(parsed)
+
+    if worksheet_casos is not None and "Numero_Foraneo" in headers_casos:
+        try:
+            col_idx = headers_casos.index("Numero_Foraneo") + 1
+            values = worksheet_casos.col_values(col_idx)
+        except Exception:
+            values = []
+
+        for raw in values[1:]:
+            parsed = _parse_foraneo_number(raw)
+            if parsed is not None:
+                used_numbers.add(parsed)
+
+    next_number = 1
+    while next_number in used_numbers:
+        next_number += 1
+
+    return f"{next_number:02d}"
 
 
 def _parse_row_sort_datetime(row: pd.Series) -> pd.Timestamp:
@@ -2087,22 +2123,17 @@ def resolve_flow_display_number(row: pd.Series, fallback_order: Any) -> str:
 
 def resolve_case_foraneo_display_number(row: pd.Series, fallback_order: Any) -> str:
     """Resuelve número visible de casos foráneos alineado al flujo visible de app_i."""
-
-    row_key = _flow_row_key(row)
-    id_key = _flow_key(row.get("ID_Pedido", ""))
-    folio_key = _flow_key(row.get("Folio_Factura", ""))
-    map_foraneo = st.session_state.get("flow_number_map_foraneo", {})
-
-    for key in (row_key, id_key, folio_key):
-        if key and key in map_foraneo:
-            return map_foraneo[key]
-
     tipo_envio = _normalize_text_for_matching(str(row.get("Tipo_Envio", "")))
     tipo_original = _normalize_text_for_matching(str(row.get("Tipo_Envio_Original", "")))
-    if "foraneo" in f"{tipo_envio} {tipo_original}":
-        parsed = _parse_foraneo_number(row.get("Numero_Foraneo", ""))
-        if parsed is not None:
-            return f"{parsed:02d}"
+    is_foraneo_case = "foraneo" in f"{tipo_envio} {tipo_original}"
+
+    # En casos/devoluciones/garantías, si existe Numero_Foraneo explícito en hoja,
+    # ese valor es la fuente de verdad para mostrar y reservar numeración.
+    parsed_manual = _parse_foraneo_number(row.get("Numero_Foraneo", ""))
+    if is_foraneo_case and parsed_manual is not None:
+        return f"{parsed_manual:02d}"
+
+    if is_foraneo_case:
         return "Sin asignar"
 
     return str(fallback_order)
@@ -7485,12 +7516,11 @@ if df_main is not None:
                     assign_col, info_col = st.columns([1, 2])
                     with assign_col:
                         if st.button("Asignar número foráneo", key=f"assign_num_foraneo_{row_key}"):
-                            max_actual = 0
-                            for val in st.session_state.get("flow_number_map_foraneo", {}).values():
-                                parsed = _parse_foraneo_number(val)
-                                if parsed and parsed > max_actual:
-                                    max_actual = parsed
-                            siguiente = f"{max_actual + 1:02d}"
+                            siguiente = _get_next_foraneo_number(
+                                worksheet_casos=worksheet_casos,
+                                headers_casos=headers_casos,
+                                flow_map_foraneo=st.session_state.get("flow_number_map_foraneo", {}),
+                            )
 
                             try:
                                 row_idx_int = int(float(row_idx_case)) if row_idx_case is not None and not pd.isna(row_idx_case) else None
@@ -8194,19 +8224,18 @@ if df_main is not None:
                 row_idx_case = row.get("_gsheet_row_index", row.get("gsheet_row_index"))
                 numero_case_actual = _parse_foraneo_number(row.get("Numero_Foraneo", ""))
                 if is_foraneo_case:
-                    if numero_case_actual is not None:
-                        st.markdown(f"**🔢 Número foráneo asignado:** `{numero_case_actual:02d}`")
+                    if numero_foraneo_visible:
+                        st.markdown(f"**🔢 Número foráneo asignado:** `{numero_foraneo_visible}`")
 
                 if is_foraneo_case:
                     assign_col, info_col = st.columns([1, 2])
                     with assign_col:
                         if st.button("Asignar número foráneo", key=f"assign_num_foraneo_g_{unique_suffix}"):
-                            max_actual = 0
-                            for val in st.session_state.get("flow_number_map_foraneo", {}).values():
-                                parsed = _parse_foraneo_number(val)
-                                if parsed and parsed > max_actual:
-                                    max_actual = parsed
-                            siguiente = f"{max_actual + 1:02d}"
+                            siguiente = _get_next_foraneo_number(
+                                worksheet_casos=worksheet_casos,
+                                headers_casos=headers_casos,
+                                flow_map_foraneo=st.session_state.get("flow_number_map_foraneo", {}),
+                            )
 
                             try:
                                 row_idx_int = int(float(row_idx_case)) if row_idx_case is not None and not pd.isna(row_idx_case) else None


### PR DESCRIPTION
### Motivation

- Ensure foráneo case numbering does not collide by considering both in-memory flow maps and existing values in the `worksheet_casos` sheet when picking the next available `Numero_Foraneo`.
- Avoid false negatives/positives when detecting the literal business type `🚚 Pedido Foráneo` by normalizing and stripping decorative prefixes and handling empty/None safely.
- Make the visible foráneo number deterministic by preferring an explicit `Numero_Foraneo` from the sheet for cases/devoluciones/garantías.

### Description

- Added helper ` _get_next_foraneo_number(worksheet_casos, headers_casos, flow_map_foraneo)` which collects used numbers from the provided flow map and the `Numero_Foraneo` column in the sheet and returns the next free two-digit string.
- Hardened `_is_exact_pedido_foraneo` to tolerate `None`/empty inputs and strip leading non-alphanumeric characters before comparing the normalized string.
- Changed `resolve_case_foraneo_display_number` to prefer an explicit `Numero_Foraneo` parsed from the sheet for foráneo cases, returning `"Sin asignar"` if a foráneo case lacks a number instead of falling back to flow map lookup.
- Replaced ad-hoc max-search logic in UI buttons with calls to `_get_next_foraneo_number`, and updated places that render the assigned number to use the resolved visible value `numero_foraneo_visible`.

### Testing

- Ran the project's automated test suite and linters against the modified module and they completed without failures.
- Executed a quick UI smoke test around the "Asignar número foráneo" flows to confirm the new number selection and sheet update path work as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef839c0b648326a8f39f15252cfbfc)