### PR TITLE
Asignación consistente de `Numero_Foraneo` y detección robusta de 'Pedido Foráneo'

### DIFF
--- a/app_a-d.py
+++ b/app_a-d.py
@@ -1821,7 +1821,11 @@ def _normalize_text_for_matching(text: str) -> str:
 
 def _is_exact_pedido_foraneo(tipo_envio: Any) -> bool:
     """True solo para el literal de negocio '🚚 Pedido Foráneo' (normalizado)."""
-    return _normalize_text_for_matching(str(tipo_envio)) == "🚚 pedido foraneo"
+    tipo_norm = _normalize_text_for_matching(str(tipo_envio or ""))
+    # Permite variantes visuales del mismo literal (emoji/prefijos),
+    # sin confundir otros tipos de envío que solo contienen "foraneo".
+    tipo_norm = re.sub(r"^[^a-z0-9]+", "", tipo_norm)
+    return tipo_norm == "pedido foraneo"
 
 
 def _flow_key(value: Any) -> str:
@@ -1875,6 +1879,38 @@ def _parse_foraneo_number(raw: Any) -> Optional[int]:
     except ValueError:
         return None
     return value if value > 0 else None
+
+
+def _get_next_foraneo_number(
+    worksheet_casos: Any,
+    headers_casos: list[str],
+    flow_map_foraneo: Optional[dict[str, str]] = None,
+) -> str:
+    """Calcula el siguiente número foráneo libre usando mapa de flujo + hoja actual."""
+    used_numbers: set[int] = set()
+
+    for val in (flow_map_foraneo or {}).values():
+        parsed = _parse_foraneo_number(val)
+        if parsed is not None:
+            used_numbers.add(parsed)
+
+    if worksheet_casos is not None and "Numero_Foraneo" in headers_casos:
+        try:
+            col_idx = headers_casos.index("Numero_Foraneo") + 1
+            values = worksheet_casos.col_values(col_idx)
+        except Exception:
+            values = []
+
+        for raw in values[1:]:
+            parsed = _parse_foraneo_number(raw)
+            if parsed is not None:
+                used_numbers.add(parsed)
+
+    next_number = 1
+    while next_number in used_numbers:
+        next_number += 1
+
+    return f"{next_number:02d}"
 
 
 def _parse_row_sort_datetime(row: pd.Series) -> pd.Timestamp:
@@ -2087,22 +2123,17 @@ def resolve_flow_display_number(row: pd.Series, fallback_order: Any) -> str:
 
 def resolve_case_foraneo_display_number(row: pd.Series, fallback_order: Any) -> str:
     """Resuelve número visible de casos foráneos alineado al flujo visible de app_i."""
-
-    row_key = _flow_row_key(row)
-    id_key = _flow_key(row.get("ID_Pedido", ""))
-    folio_key = _flow_key(row.get("Folio_Factura", ""))
-    map_foraneo = st.session_state.get("flow_number_map_foraneo", {})
-
-    for key in (row_key, id_key, folio_key):
-        if key and key in map_foraneo:
-            return map_foraneo[key]
-
     tipo_envio = _normalize_text_for_matching(str(row.get("Tipo_Envio", "")))
     tipo_original = _normalize_text_for_matching(str(row.get("Tipo_Envio_Original", "")))
-    if "foraneo" in f"{tipo_envio} {tipo_original}":
-        parsed = _parse_foraneo_number(row.get("Numero_Foraneo", ""))
-        if parsed is not None:
-            return f"{parsed:02d}"
+    is_foraneo_case = "foraneo" in f"{tipo_envio} {tipo_original}"
+
+    # En casos/devoluciones/garantías, si existe Numero_Foraneo explícito en hoja,
+    # ese valor es la fuente de verdad para mostrar y reservar numeración.
+    parsed_manual = _parse_foraneo_number(row.get("Numero_Foraneo", ""))
+    if is_foraneo_case and parsed_manual is not None:
+        return f"{parsed_manual:02d}"
+
+    if is_foraneo_case:
         return "Sin asignar"
 
     return str(fallback_order)
@@ -7478,19 +7509,18 @@ if df_main is not None:
                 row_idx_case = row.get("_gsheet_row_index", row.get("gsheet_row_index"))
                 numero_case_actual = _parse_foraneo_number(row.get("Numero_Foraneo", ""))
                 if is_foraneo_case:
-                    if numero_foraneo_visible:
-                        st.markdown(f"**🔢 Número foráneo asignado:** `{numero_foraneo_visible}`")
+                    if numero_case_actual is not None:
+                        st.markdown(f"**🔢 Número foráneo asignado:** `{numero_case_actual:02d}`")
 
                 if is_foraneo_case:
                     assign_col, info_col = st.columns([1, 2])
                     with assign_col:
                         if st.button("Asignar número foráneo", key=f"assign_num_foraneo_{row_key}"):
-                            max_actual = 0
-                            for val in st.session_state.get("flow_number_map_foraneo", {}).values():
-                                parsed = _parse_foraneo_number(val)
-                                if parsed and parsed > max_actual:
-                                    max_actual = parsed
-                            siguiente = f"{max_actual + 1:02d}"
+                            siguiente = _get_next_foraneo_number(
+                                worksheet_casos=worksheet_casos,
+                                headers_casos=headers_casos,
+                                flow_map_foraneo=st.session_state.get("flow_number_map_foraneo", {}),
+                            )
 
                             try:
                                 row_idx_int = int(float(row_idx_case)) if row_idx_case is not None and not pd.isna(row_idx_case) else None
@@ -8201,12 +8231,11 @@ if df_main is not None:
                     assign_col, info_col = st.columns([1, 2])
                     with assign_col:
                         if st.button("Asignar número foráneo", key=f"assign_num_foraneo_g_{unique_suffix}"):
-                            max_actual = 0
-                            for val in st.session_state.get("flow_number_map_foraneo", {}).values():
-                                parsed = _parse_foraneo_number(val)
-                                if parsed and parsed > max_actual:
-                                    max_actual = parsed
-                            siguiente = f"{max_actual + 1:02d}"
+                            siguiente = _get_next_foraneo_number(
+                                worksheet_casos=worksheet_casos,
+                                headers_casos=headers_casos,
+                                flow_map_foraneo=st.session_state.get("flow_number_map_foraneo", {}),
+                            )
 
                             try:
                                 row_idx_int = int(float(row_idx_case)) if row_idx_case is not None and not pd.isna(row_idx_case) else None


### PR DESCRIPTION
### Motivation
- Evitar colisiones al asignar números foráneos usando tanto el mapa de flujo en memoria como los valores ya presentes en la hoja de casos. 
- Asegurar que la identificación de "🚚 Pedido Foráneo" no falle por variantes visuales o valores nulos. 

### Description
- Añade la función `_get_next_foraneo_number(...)` que calcula el siguiente número libre consultando `flow_map_foraneo` y la columna `Numero_Foraneo` de la hoja `worksheet_casos` y lo devuelve formateado con dos dígitos. 
- Refina `_is_exact_pedido_foraneo(...)` para normalizar entradas nulas y eliminar prefijos/emoji/caras visuales antes de comparar el literal "pedido foraneo". 
- Modifica `resolve_case_foraneo_display_number(...)` para preferir un `Numero_Foraneo` explícito presente en la hoja y devolver "Sin asignar" cuando el caso es foráneo pero no existe número manual. 
- Reemplaza la lógica inline previa que calculaba el siguiente número por búsqueda del máximo en memoria por llamadas a `_get_next_foraneo_number(...)` en las UI de asignación dentro de los expanders (devoluciones y garantías), y muestra siempre el número actual formateado con dos dígitos cuando existe. 

### Testing
- Se ejecutó la suite automatizada del proyecto con `pytest` y la ejecución completó correctamente sin fallos. 
- Se ejecutaron pruebas de integración local (suite automatizada) que cubren las utilidades de parseo/serialización y finalización de flujos relacionadas con `Numero_Foraneo` y pasaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef839c0b648326a8f39f15252cfbfc)