### PR TITLE
Normalize folio matching for Pasa_Bodega upsert to handle Sheet formatting

### DIFF
--- a/app_a-d.py
+++ b/app_a-d.py
@@ -1161,6 +1161,14 @@ def _upsert_pasa_bodega_report_row(row: Any) -> bool:
         st.warning("⚠️ No se pudo registrar en Pasa_Bodega: Folio_Factura vacío.")
         return False
 
+    def _folio_key(value: Any) -> str:
+        text = normalize_sheet_text(value).strip().lower()
+        if text.endswith(".0"):
+            maybe_num = text[:-2]
+            if maybe_num.replace("-", "").isdigit():
+                text = maybe_num
+        return text
+
     payload = {
         "FECHA DE FACTURA": _format_pasa_bodega_date(row.get("Fecha_Entrega", "")),
         "NUMERO DE FACTURA": folio_factura,
@@ -1192,9 +1200,10 @@ def _upsert_pasa_bodega_report_row(row: Any) -> bool:
     num_col_idx = headers.index("NUMERO DE FACTURA") + 1
     target_row = None
     try:
+        folio_target_key = _folio_key(folio_factura)
         col_values = ws.col_values(num_col_idx)
         for i, val in enumerate(col_values[1:], start=2):
-            if str(val or "").strip() == folio_factura:
+            if _folio_key(val) == folio_target_key:
                 target_row = i
                 break
     except Exception:
@@ -3735,7 +3744,6 @@ def completar_pedido(
             "values": [[now_str]],
         },
     ]
-
     if not batch_update_gsheet_cells(worksheet, updates, headers=headers):
         st.error("❌ No se pudo completar el pedido.")
         return False


### PR DESCRIPTION
### Motivation
- Ensure invoice lookup in `Pasa_Bodega` is robust against common Google Sheets formatting differences (extra whitespace, case differences and trailing `.0` on numeric strings) so existing rows are found and updated reliably.

### Description
- Add helper ` _folio_key(value: Any) -> str` that calls `normalize_sheet_text`, trims and lowercases the value and strips a trailing `.0` when the remainder is numeric-like.
- Use `folio_target_key = _folio_key(folio_factura)` and compare `if _folio_key(val) == folio_target_key` while scanning the `NUMERO DE FACTURA` column to reliably detect the target row before updating or appending.

### Testing
- Ran the test suite with `pytest -q` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef929c29888326a1f12c15f51c518d)