### PR TITLE
Agregar filtro por vendedor en Organizador → Check de Facturas

### DIFF
--- a/app_gerente.py
+++ b/app_gerente.py
@@ -6023,6 +6023,28 @@ if "organizador" in tab_map:
 
                         total_archivo = int(len(df_facturas))
                         total_no_encontradas = int(len(df_no_encontradas))
+
+                        vendedores_disponibles_check = sorted(
+                            {
+                                str(v).strip()
+                                for v in df_no_encontradas.get("Vendedor", pd.Series(dtype=str)).dropna().tolist()
+                                if str(v).strip()
+                            }
+                        )
+                        opciones_vendedor_check = ["👥 Todos"] + vendedores_disponibles_check
+                        filtro_vendedor_check = st.selectbox(
+                            "Filtrar lista por vendedor",
+                            options=opciones_vendedor_check,
+                            index=0,
+                            key="organizador_check_facturas_filtro_vendedor",
+                        )
+                        if filtro_vendedor_check == "👥 Todos":
+                            df_no_encontradas_filtrado = df_no_encontradas.copy()
+                        else:
+                            df_no_encontradas_filtrado = df_no_encontradas[
+                                df_no_encontradas.get("Vendedor", "").astype(str).str.strip() == filtro_vendedor_check
+                            ].copy()
+
                         st.info(
                             f"Facturas analizadas: {total_archivo} | "
                             f"No encontradas en sistema: {total_no_encontradas}"
@@ -6047,10 +6069,14 @@ if "organizador" in tab_map:
                                 "⚠️ Estas facturas (últimas 72h) no tienen match válido en data_pedidos/datos_pedidos "
                                 "considerando Folio_Factura/Adjuntos/Cliente + regla de fecha:"
                             )
-                            st.dataframe(df_no_encontradas, use_container_width=True)
+                            st.caption(
+                                f"Vendedor seleccionado: {filtro_vendedor_check} | "
+                                f"Resultados mostrados: {len(df_no_encontradas_filtrado)}"
+                            )
+                            st.dataframe(df_no_encontradas_filtrado, use_container_width=True)
                             st.download_button(
                                 "⬇️ Descargar faltantes (CSV)",
-                                data=df_no_encontradas.to_csv(index=False).encode("utf-8-sig"),
+                                data=df_no_encontradas_filtrado.to_csv(index=False).encode("utf-8-sig"),
                                 file_name="facturas_no_encontradas.csv",
                                 mime="text/csv",
                                 key="organizador_check_facturas_descargar_csv",


### PR DESCRIPTION
### Motivation
- Permitir filtrar las facturas "no encontradas" por vendedor en la subpestaña `🧾 Check de Facturas` para revisar y descargar solo los resultados de un vendedor específico sin romper el flujo existente.

### Description
- Se añadió un `selectbox` `organizador_check_facturas_filtro_vendedor` que genera opciones desde `df_no_encontradas` y usa `"👥 Todos"` como valor por defecto para mantener el comportamiento previo; los cambios están en `app_gerente.py`.
- Se crea `df_no_encontradas_filtrado` según la selección y se actualizan la vista (`st.dataframe`) y la descarga CSV (`st.download_button`) para usar el DataFrame filtrado, además de mostrar un `st.caption` con el vendedor seleccionado y el conteo de resultados.

### Testing
- Se compiló el archivo modificado con `python -m py_compile app_gerente.py` y la compilación finalizó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efa0143a408326b6ea32b165bb725b)