### PR TITLE
Fix: use live Google Sheet headers when confirming Modificacion_Surtido

### DIFF
--- a/app_a-d.py
+++ b/app_a-d.py
@@ -3106,8 +3106,16 @@ def confirmar_modificacion_surtido(
     mod_texto,
 ):
     """Confirma modificación de surtido priorizando batch y con fallback seguro."""
+    live_headers = list(headers or [])
+    try:
+        fetched_headers = worksheet.row_values(1)
+        if fetched_headers:
+            live_headers = fetched_headers
+    except Exception:
+        # Si falla la lectura de encabezados, usamos los que ya traíamos en memoria.
+        live_headers = list(headers or [])
 
-    if "Modificacion_Surtido" not in headers:
+    if "Modificacion_Surtido" not in live_headers:
         st.error("❌ No existe la columna 'Modificacion_Surtido' para confirmar el cambio.")
         return False
 
@@ -3117,57 +3125,57 @@ def confirmar_modificacion_surtido(
         {
             "range": gspread.utils.rowcol_to_a1(
                 gsheet_row_index,
-                headers.index("Modificacion_Surtido") + 1,
+                live_headers.index("Modificacion_Surtido") + 1,
             ),
             "values": [[texto_confirmado]],
         }
     ]
 
-    if "Estado" in headers:
+    if "Estado" in live_headers:
         updates.append(
             {
                 "range": gspread.utils.rowcol_to_a1(
                     gsheet_row_index,
-                    headers.index("Estado") + 1,
+                    live_headers.index("Estado") + 1,
                 ),
                 "values": [["🔵 En Proceso"]],
             }
         )
 
-    if "Hora_Proceso" in headers:
+    if "Hora_Proceso" in live_headers:
         updates.append(
             {
                 "range": gspread.utils.rowcol_to_a1(
                     gsheet_row_index,
-                    headers.index("Hora_Proceso") + 1,
+                    live_headers.index("Hora_Proceso") + 1,
                 ),
                 "values": [[mx_now_str()]],
             }
         )
 
-    if batch_update_gsheet_cells(worksheet, updates, headers=headers):
+    if batch_update_gsheet_cells(worksheet, updates, headers=live_headers):
         return True
 
     # Fallback resiliente: conservar funcionalidad aunque falle la operación batch.
     ok = update_gsheet_cell(
         worksheet,
-        headers,
+        live_headers,
         gsheet_row_index,
         "Modificacion_Surtido",
         texto_confirmado,
     )
-    if ok and "Estado" in headers:
+    if ok and "Estado" in live_headers:
         ok = update_gsheet_cell(
             worksheet,
-            headers,
+            live_headers,
             gsheet_row_index,
             "Estado",
             "🔵 En Proceso",
         )
-    if ok and "Hora_Proceso" in headers:
+    if ok and "Hora_Proceso" in live_headers:
         ok = update_gsheet_cell(
             worksheet,
-            headers,
+            live_headers,
             gsheet_row_index,
             "Hora_Proceso",
             mx_now_str(),


### PR DESCRIPTION
### Motivation
- Prevent writes from landing in wrong columns when in-memory `headers` are stale compared to the real sheet, which causes confirmation text or timestamps to appear in `Estado` or other columns.
- Ensure the confirmation flow for devoluciones consistently writes confirmation text, sets `Estado` and records `Hora_Proceso` in the intended columns.

### Description
- `confirmar_modificacion_surtido` now attempts to fetch live headers with `worksheet.row_values(1)` and falls back to the passed `headers` if fetching fails.
- All column index lookups and the `batch_update_gsheet_cells` call were changed to use the new `live_headers` mapping so batch writes target the correct A1 ranges.
- The fallback single-cell updates (`update_gsheet_cell`) also use `live_headers` for consistent column mapping.
- Behavior is unchanged when header fetch fails: the function uses the provided `headers` and retains the existing batch + resilient per-cell fallback logic.

### Testing
- Compiled the modified module with `python -m py_compile app_a-d.py` and the compile completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efe82aef9483269a154b37c3f719bd)