### PR TITLE
Add Facturas_Faltantes parsing, check logic, sheet I/O and dashboard UI

### DIFF
--- a/app_gerente.py
+++ b/app_gerente.py
@@ -162,6 +162,7 @@ PEDIDOS_COLUMNAS_MINIMAS = [
     "Refacturacion_Tipo", "Refacturacion_Subtipo", "Folio_Factura_Refacturada", "fecha_modificacion", "Fecha_Modificacion",
     "Tipo_Envio", "id_vendedor", "ID_Vendedor", "Id_Vendedor"
 ]
+FACTURAS_FALTANTES_COLUMNAS = ["Vendedor", "FolioSerie", "Cliente", "Fecha"]
 
 # ===== ALEJANDRO DATA (Organizador) =====
 ALE_SHEETS = (
@@ -262,6 +263,43 @@ def _extract_sheet_id(value: str) -> str:
     if m:
         return m.group(1)
     return raw
+
+
+def guardar_facturas_faltantes_en_sheet(df_faltantes: pd.DataFrame) -> tuple[bool, str]:
+    """Reemplaza por completo la hoja Facturas_Faltantes con columnas limpias del check."""
+    try:
+        ws = get_main_worksheet("Facturas_Faltantes")
+        df_out = df_faltantes.copy() if isinstance(df_faltantes, pd.DataFrame) else pd.DataFrame()
+        for col in FACTURAS_FALTANTES_COLUMNAS:
+            if col not in df_out.columns:
+                df_out[col] = ""
+            df_out[col] = df_out[col].astype(str).fillna("").str.strip()
+        df_out = df_out[FACTURAS_FALTANTES_COLUMNAS].drop_duplicates().reset_index(drop=True)
+        values = [FACTURAS_FALTANTES_COLUMNAS] + df_out.values.tolist()
+
+        if hasattr(ws, "clear"):
+            ws.clear()
+
+        if hasattr(ws, "update"):
+            ws.update("A1", values, value_input_option="USER_ENTERED")
+        elif hasattr(ws, "batch_update"):
+            ws.batch_update([{"range": "A1", "values": values}])
+        elif hasattr(ws, "update_cells"):
+            total_rows = len(values)
+            total_cols = max((len(r) for r in values), default=0)
+            cells = []
+            for r_idx in range(total_rows):
+                row_vals = values[r_idx]
+                for c_idx in range(total_cols):
+                    val = row_vals[c_idx] if c_idx < len(row_vals) else ""
+                    cells.append(gspread.Cell(row=r_idx + 1, col=c_idx + 1, value=str(val)))
+            ws.update_cells(cells)
+        else:
+            return False, "La versión de gspread no soporta escritura compatible."
+
+        return True, f"Facturas_Faltantes actualizada con {len(df_out)} fila(s)."
+    except Exception as e:
+        return False, f"No se pudo guardar Facturas_Faltantes: {e}"
 
 
 def _is_truthy(value) -> bool:
@@ -6096,6 +6134,15 @@ if "organizador" in tab_map:
                                 "df_no_encontradas": df_no_encontradas.copy(),
                                 "df_match_cliente_sin_folio": df_match_cliente_sin_folio.copy(),
                             }
+
+                        guardado_sig_key = "organizador_check_facturas_guardado_sig"
+                        if st.session_state.get(guardado_sig_key) != firma_archivo:
+                            ok_guardado_ff, msg_guardado_ff = guardar_facturas_faltantes_en_sheet(df_no_encontradas)
+                            if ok_guardado_ff:
+                                st.session_state[guardado_sig_key] = firma_archivo
+                                st.success(f"✅ {msg_guardado_ff}")
+                            else:
+                                st.error(f"❌ {msg_guardado_ff}")
 
                         vendedores_disponibles_check = sorted(
                             {

--- a/app_i-d.py
+++ b/app_i-d.py
@@ -2680,6 +2680,10 @@ SHEET_CONFIRMADOS = "pedidos_confirmados"
 SHEET_PEDIDOS_HISTORICOS = "datos_pedidos"
 SHEET_ZONAS_REMOTAS = "Zonas_Remotas"
 SHEET_PRODUCTOS = "Productos"
+SHEET_FACTURAS_FALTANTES = "Facturas_Faltantes"
+
+FACTURAS_FALTANTES_REQUIRED_COLUMNS = ["Vendedor", "FolioSerie", "Cliente", "Fecha"]
+FACTURAS_FALTANTES_ALLOWED_USERS = {"SCHAVA", "ALEJANDRO38"}
 
 
 # --- Auth helpers ---
@@ -3249,6 +3253,288 @@ def _clean_cliente_name(x: str) -> str:
 
 def _normalize_vendedor_name(value) -> str:
     return sanitize_text(value).casefold()
+
+
+def _normalize_header_token(value: object) -> str:
+    text = sanitize_text(value).strip().lower()
+    text = unicodedata.normalize("NFKD", text)
+    text = "".join(ch for ch in text if not unicodedata.combining(ch))
+    return re.sub(r"[^a-z0-9]", "", text)
+
+
+def _find_column_by_alias(df: pd.DataFrame, aliases: list[str]) -> Optional[str]:
+    if df.empty:
+        return None
+    normalized_aliases = {_normalize_header_token(a) for a in aliases}
+    for col in df.columns:
+        if _normalize_header_token(col) in normalized_aliases:
+            return col
+    return None
+
+
+def _parse_facturas_faltantes_upload(uploaded_file) -> tuple[pd.DataFrame, str]:
+    if uploaded_file is None:
+        return pd.DataFrame(), "No se recibió archivo."
+
+    filename = sanitize_text(uploaded_file.name).lower()
+
+    def _read_with_header(header_idx: int) -> tuple[pd.DataFrame, str]:
+        try:
+            uploaded_file.seek(0)
+            if filename.endswith(".csv"):
+                work_df = pd.read_csv(uploaded_file, header=header_idx, dtype=str, keep_default_na=False)
+            else:
+                work_df = pd.read_excel(uploaded_file, header=header_idx, dtype=str)
+            return work_df, ""
+        except Exception as exc:
+            return pd.DataFrame(), str(exc)
+
+    def _extract_required_columns(work_df: pd.DataFrame) -> tuple[pd.DataFrame, str]:
+        if work_df.empty:
+            return pd.DataFrame(), "El archivo no contiene filas con datos."
+
+        col_vendedor = _find_column_by_alias(work_df, ["Vendedor"])
+        col_folio = _find_column_by_alias(work_df, ["FolioSerie", "Folio", "Folio_Serie"])
+        col_cliente = _find_column_by_alias(work_df, ["Cliente"])
+        col_fecha = _find_column_by_alias(work_df, ["Fecha", "FechaFactura"])
+
+        missing = []
+        if col_vendedor is None:
+            missing.append("Vendedor")
+        if col_folio is None:
+            missing.append("FolioSerie")
+        if col_cliente is None:
+            missing.append("Cliente")
+        if col_fecha is None:
+            missing.append("Fecha")
+        if missing:
+            return pd.DataFrame(), f"No se encontraron columnas requeridas: {', '.join(missing)}"
+
+        parsed_df = work_df[[col_vendedor, col_folio, col_cliente, col_fecha]].copy()
+        parsed_df.columns = FACTURAS_FALTANTES_REQUIRED_COLUMNS
+        parsed_df = parsed_df.fillna("")
+        for col in FACTURAS_FALTANTES_REQUIRED_COLUMNS:
+            parsed_df[col] = parsed_df[col].astype(str).map(sanitize_text)
+        parsed_df = parsed_df[parsed_df["FolioSerie"] != ""].copy()
+        parsed_df = parsed_df.drop_duplicates().reset_index(drop=True)
+
+        if parsed_df.empty:
+            return pd.DataFrame(), "No se detectaron folios válidos después de limpiar el archivo."
+        return parsed_df, ""
+
+    # Soporta encabezados en fila 1 (como en la captura) y fallback a fila 3.
+    work_header_1, err_h1 = _read_with_header(0)
+    parsed_header_1, parse_h1_err = _extract_required_columns(work_header_1)
+    if not parsed_header_1.empty:
+        return parsed_header_1, ""
+
+    work_header_3, err_h3 = _read_with_header(2)
+    parsed_header_3, parse_h3_err = _extract_required_columns(work_header_3)
+    if not parsed_header_3.empty:
+        return parsed_header_3, ""
+
+    if err_h1 and err_h3:
+        return pd.DataFrame(), f"No se pudo leer el archivo: {err_h1}"
+    return pd.DataFrame(), (
+        "No se encontraron las columnas requeridas con encabezado en fila 1 ni en fila 3. "
+        f"Detalle fila 1: {parse_h1_err or 'sin columnas válidas'}. "
+        f"Detalle fila 3: {parse_h3_err or 'sin columnas válidas'}."
+    )
+
+
+@st.cache_data(ttl=120, show_spinner=False)
+def load_facturas_faltantes_from_gsheets() -> pd.DataFrame:
+    try:
+        ws = _open_worksheet_with_retry(
+            g_spread_client,
+            GOOGLE_SHEET_ID,
+            SHEET_FACTURAS_FALTANTES,
+            max_attempts=2,
+            cooldown_seconds=90,
+        )
+        records = ws.get_all_records()
+        df = pd.DataFrame(records)
+    except Exception:
+        return pd.DataFrame(columns=FACTURAS_FALTANTES_REQUIRED_COLUMNS)
+
+    for col in FACTURAS_FALTANTES_REQUIRED_COLUMNS:
+        if col not in df.columns:
+            df[col] = ""
+        df[col] = df[col].astype(str).map(sanitize_text)
+
+    return df[FACTURAS_FALTANTES_REQUIRED_COLUMNS].copy()
+
+
+def replace_facturas_faltantes_sheet(df_new: pd.DataFrame) -> tuple[bool, str]:
+    if df_new.empty:
+        return False, "No hay filas para guardar."
+
+    try:
+        ws = _open_worksheet_with_retry(
+            g_spread_client,
+            GOOGLE_SHEET_ID,
+            SHEET_FACTURAS_FALTANTES,
+            max_attempts=2,
+            cooldown_seconds=90,
+        )
+        rows_to_write = [FACTURAS_FALTANTES_REQUIRED_COLUMNS] + (
+            df_new[FACTURAS_FALTANTES_REQUIRED_COLUMNS].fillna("").astype(str).values.tolist()
+        )
+        if hasattr(ws, "clear"):
+            ws.clear()
+
+        if hasattr(ws, "update"):
+            ws.update("A1", rows_to_write, value_input_option="USER_ENTERED")
+        elif hasattr(ws, "batch_update"):
+            ws.batch_update([{"range": "A1", "values": rows_to_write}])
+        elif hasattr(ws, "update_cells"):
+            total_rows = len(rows_to_write)
+            total_cols = max((len(r) for r in rows_to_write), default=0)
+            cells = []
+            for r_idx in range(total_rows):
+                row_values = rows_to_write[r_idx]
+                for c_idx in range(total_cols):
+                    val = row_values[c_idx] if c_idx < len(row_values) else ""
+                    cells.append(gspread.Cell(row=r_idx + 1, col=c_idx + 1, value=str(val)))
+            ws.update_cells(cells)
+        else:
+            return False, "La versión actual de gspread no soporta método de escritura compatible."
+
+        load_facturas_faltantes_from_gsheets.clear()
+        return True, f"Se cargaron {len(df_new)} fila(s) en {SHEET_FACTURAS_FALTANTES}."
+    except Exception as exc:
+        return False, f"No se pudo guardar en Google Sheets: {exc}"
+
+
+def _normalize_factura_key(value: object) -> str:
+    text = sanitize_text(value).lower()
+    text = unicodedata.normalize("NFKD", text)
+    text = "".join(ch for ch in text if not unicodedata.combining(ch))
+    return re.sub(r"[^a-z0-9]", "", text)
+
+
+def _extract_possible_folios(value: object) -> set[str]:
+    normalized = _normalize_factura_key(value)
+    if not normalized:
+        return set()
+    tokens = re.findall(r"[a-z]*\d{3,}[a-z0-9]*", normalized)
+    return {tok for tok in tokens if tok}
+
+
+def _run_facturas_faltantes_check(df_facturas: pd.DataFrame) -> dict[str, object]:
+    empty_result = {
+        "total_archivo": 0,
+        "total_no_encontradas": 0,
+        "limite_72h": None,
+        "ahora": None,
+        "df_no_encontradas": pd.DataFrame(columns=FACTURAS_FALTANTES_REQUIRED_COLUMNS),
+        "df_match_cliente": pd.DataFrame(columns=FACTURAS_FALTANTES_REQUIRED_COLUMNS),
+    }
+    if df_facturas.empty:
+        return empty_result
+
+    work = df_facturas.copy()
+    for col in FACTURAS_FALTANTES_REQUIRED_COLUMNS:
+        if col not in work.columns:
+            work[col] = ""
+        work[col] = work[col].astype(str).map(sanitize_text)
+    work["Fecha_dt"] = pd.to_datetime(work["Fecha"], errors="coerce", dayfirst=True)
+    work = work[work["Fecha_dt"].notna()].copy()
+    if work.empty:
+        return empty_result
+
+    ahora = pd.Timestamp.now(tz=TZ).tz_localize(None)
+    limite_72h = ahora - timedelta(hours=72)
+    work = work[(work["Fecha_dt"] >= limite_72h) & (work["Fecha_dt"] <= ahora)].copy()
+    if work.empty:
+        return {
+            **empty_result,
+            "limite_72h": limite_72h,
+            "ahora": ahora,
+        }
+
+    df_actual = load_data_from_gsheets().copy()
+    df_hist = load_historicos_from_gsheets().copy()
+    pedidos = pd.concat([df_actual, df_hist], ignore_index=True, sort=False)
+    if pedidos.empty:
+        no_encontradas = work[FACTURAS_FALTANTES_REQUIRED_COLUMNS].drop_duplicates().reset_index(drop=True)
+        return {
+            "total_archivo": int(len(work)),
+            "total_no_encontradas": int(len(no_encontradas)),
+            "limite_72h": limite_72h,
+            "ahora": ahora,
+            "df_no_encontradas": no_encontradas,
+            "df_match_cliente": pd.DataFrame(columns=FACTURAS_FALTANTES_REQUIRED_COLUMNS),
+        }
+
+    if "Hora_Registro" not in pedidos.columns:
+        pedidos["Hora_Registro"] = pd.NaT
+    pedidos["Hora_Registro_dt"] = pd.to_datetime(pedidos["Hora_Registro"], errors="coerce")
+    if "Folio_Factura" not in pedidos.columns:
+        pedidos["Folio_Factura"] = ""
+    if "Cliente" not in pedidos.columns:
+        pedidos["Cliente"] = ""
+
+    pedidos["Folio_Set"] = pedidos["Folio_Factura"].apply(_extract_possible_folios)
+    adj_cols = [c for c in ["Adjuntos", "Adjuntos_Surtido"] if c in pedidos.columns]
+    if adj_cols:
+        pedidos["Adjuntos_Set"] = pedidos[adj_cols].fillna("").astype(str).agg(" ".join, axis=1).apply(_extract_possible_folios)
+    else:
+        pedidos["Adjuntos_Set"] = [set() for _ in range(len(pedidos))]
+    pedidos["Cliente_norm"] = pedidos["Cliente"].apply(_normalize_factura_key)
+
+    work["Folio_norm"] = work["FolioSerie"].apply(_normalize_factura_key)
+    work["Cliente_norm"] = work["Cliente"].apply(_normalize_factura_key)
+
+    match_folio_flags = []
+    match_cliente_flags = []
+    for _, factura in work.iterrows():
+        folio = factura["Folio_norm"]
+        cliente = factura["Cliente_norm"]
+        fecha = factura["Fecha_dt"]
+        ventana_ini_folio = fecha - timedelta(hours=72)
+        ventana_fin = fecha + timedelta(hours=72)
+
+        candidatos_folio = pedidos[
+            pedidos["Folio_Set"].apply(lambda s: bool(folio and folio in s))
+            | pedidos["Adjuntos_Set"].apply(lambda s: bool(folio and folio in s))
+        ]
+        match_folio = (
+            (not candidatos_folio.empty)
+            and candidatos_folio["Hora_Registro_dt"].between(ventana_ini_folio, ventana_fin).any()
+        )
+
+        match_cliente = False
+        if cliente and not match_folio:
+            candidatos_cliente = pedidos[
+                pedidos["Cliente_norm"].apply(lambda c: bool(c and (cliente in c or c in cliente)))
+            ]
+            match_cliente = (
+                (not candidatos_cliente.empty)
+                and candidatos_cliente["Hora_Registro_dt"].between(fecha, ventana_fin).any()
+            )
+
+        match_folio_flags.append(bool(match_folio))
+        match_cliente_flags.append(bool(match_cliente))
+
+    work["match_folio"] = match_folio_flags
+    work["match_cliente"] = match_cliente_flags
+
+    df_no_encontradas = work[~(work["match_folio"] | work["match_cliente"])][
+        FACTURAS_FALTANTES_REQUIRED_COLUMNS
+    ].drop_duplicates().reset_index(drop=True)
+    df_match_cliente = work[work["match_cliente"]][
+        FACTURAS_FALTANTES_REQUIRED_COLUMNS
+    ].drop_duplicates().reset_index(drop=True)
+
+    return {
+        "total_archivo": int(len(work)),
+        "total_no_encontradas": int(len(df_no_encontradas)),
+        "limite_72h": limite_72h,
+        "ahora": ahora,
+        "df_no_encontradas": df_no_encontradas,
+        "df_match_cliente": df_match_cliente,
+    }
 
 
 def _resolve_sales_datetime(df: pd.DataFrame) -> pd.Series:
@@ -4723,6 +5009,28 @@ if selected_tab_key == "dashboard":
         refresh_dashboard_sources()
 
     st_autorefresh(interval=60000, key="auto_refresh_dashboard")
+
+    with st.expander("🧾 Facturas faltantes por enviar", expanded=False):
+        col_ff_1, col_ff_2 = st.columns([0.7, 0.3])
+        with col_ff_1:
+            st.markdown("**Vista compartida actual (`Facturas_Faltantes`)**")
+        with col_ff_2:
+            if st.button("🔄 Actualizar lista", key="dashboard_facturas_faltantes_refresh", use_container_width=True):
+                load_facturas_faltantes_from_gsheets.clear()
+                st.rerun()
+
+        df_facturas_faltantes = load_facturas_faltantes_from_gsheets()
+        if df_facturas_faltantes.empty:
+            st.info("No hay registros en `Facturas_Faltantes`.")
+        else:
+            st.dataframe(df_facturas_faltantes, use_container_width=True, height=260, hide_index=True)
+            st.download_button(
+                "⬇️ Descargar facturas faltantes (CSV)",
+                data=df_facturas_faltantes.to_csv(index=False).encode("utf-8-sig"),
+                file_name="Facturas_Faltantes.csv",
+                mime="text/csv",
+                key="dashboard_facturas_faltantes_download",
+            )
 
     df_conf = get_cached_confirmados_df(SHEET_CONFIRMADOS)
     if df_conf.empty:


### PR DESCRIPTION
### Motivation
- Provide an automated flow to detect invoices (facturas) from uploaded files that are not found in the system and persist them to a shared `Facturas_Faltantes` sheet for team follow-up. 
- Support multiple source formats and header variants when ingesting uploaded files so the check is resilient to real report shapes. 
- Expose the current `Facturas_Faltantes` view in the dashboard and allow refreshing/downloading so users can inspect results easily.

### Description
- Added constants and required-column definitions: `SHEET_FACTURAS_FALTANTES`, `FACTURAS_FALTANTES_REQUIRED_COLUMNS`, and `FACTURAS_FALTANTES_ALLOWED_USERS` in `app_i-d.py` and `FACTURAS_FALTANTES_COLUMNAS` in `app_gerente.py`.
- Implemented parsing helpers `_normalize_header_token`, `_find_column_by_alias`, and `_parse_facturas_faltantes_upload` to read CSV/XLSX files with headers in different rows and map to the canonical columns.
- Implemented loading and replacement I/O to Google Sheets via `load_facturas_faltantes_from_gsheets` and `replace_facturas_faltantes_sheet` in `app_i-d.py` and a compatible writer `guardar_facturas_faltantes_en_sheet` in `app_gerente.py` that supports multiple gspread versions (`update`, `batch_update`, `update_cells`).
- Implemented matching logic `_normalize_factura_key`, `_extract_possible_folios`, and `_run_facturas_faltantes_check` which normalizes folios and clients, searches recent orders (including historical sheet), and computes `df_no_encontradas` and `df_match_cliente` results.
- Integrated sheet persistence into the organizer workflow in `app_gerente.py` by saving `df_no_encontradas` when a new analysis fingerprint is detected and showing success/error messages via Streamlit session state.
- Added a dashboard expander in `app_i-d.py` to preview, refresh, and download the `Facturas_Faltantes` sheet as CSV.

### Testing
- Ran the existing test suite with `pytest -q` and static checks with `flake8`, and the runs completed without failures on the modified code paths.
- Exercised cached loading and sheet-replace functions via automated unit-style runs that simulated empty/typical DataFrame inputs and confirmed expected DataFrame shapes and return tuples.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0d8068bec832697448f0b74dcc857)