### PR TITLE
Fix local subtab date/turn update column mapping

### DIFF
--- a/app_a-d.py
+++ b/app_a-d.py
@@ -5364,6 +5364,14 @@ def mostrar_pedido(df, idx, row, orden, origen_tab, current_main_tab_label, work
 
                 if aplicar_cambios:
                     st.session_state["expanded_pedidos"][row['ID_Pedido']] = True
+                    live_headers = list(headers or [])
+                    try:
+                        fetched_headers = worksheet.row_values(1)
+                        if fetched_headers:
+                            live_headers = fetched_headers
+                    except Exception:
+                        live_headers = list(headers or [])
+
                     cambios = []
                     estado_antes_cambio = str(row.get("Estado", "")).strip()
                     hora_proceso_antes_cambio = str(row.get("Hora_Proceso", "")).strip()
@@ -5372,8 +5380,11 @@ def mostrar_pedido(df, idx, row, orden, origen_tab, current_main_tab_label, work
                     hubo_cambio_fecha_turno = False
 
                     if nueva_fecha_str != fecha_actual_str:
+                        if "Fecha_Entrega" not in live_headers:
+                            st.error("❌ No se encontró la columna 'Fecha_Entrega' en Google Sheets.")
+                            return
                         hubo_cambio_fecha_turno = True
-                        col_idx = headers.index("Fecha_Entrega") + 1
+                        col_idx = live_headers.index("Fecha_Entrega") + 1
                         cambios.append(
                             {
                                 'range': gspread.utils.rowcol_to_a1(
@@ -5385,8 +5396,11 @@ def mostrar_pedido(df, idx, row, orden, origen_tab, current_main_tab_label, work
 
                     if puede_editar_turno:
                         if nuevo_turno != current_turno:
+                            if "Turno" not in live_headers:
+                                st.error("❌ No se encontró la columna 'Turno' en Google Sheets.")
+                                return
                             hubo_cambio_fecha_turno = True
-                            col_idx = headers.index("Turno") + 1
+                            col_idx = live_headers.index("Turno") + 1
                             cambios.append(
                                 {
                                     'range': gspread.utils.rowcol_to_a1(
@@ -5398,8 +5412,8 @@ def mostrar_pedido(df, idx, row, orden, origen_tab, current_main_tab_label, work
 
                     # Blindaje adicional: en este flujo el Estado no debe cambiar.
                     # Forzamos conservar el Estado en el mismo batch para evitar drift.
-                    if cambios and "Estado" in headers and estado_antes_cambio:
-                        col_idx_estado = headers.index("Estado") + 1
+                    if cambios and "Estado" in live_headers and estado_antes_cambio:
+                        col_idx_estado = live_headers.index("Estado") + 1
                         cambios.append(
                             {
                                 "range": gspread.utils.rowcol_to_a1(
@@ -5410,15 +5424,15 @@ def mostrar_pedido(df, idx, row, orden, origen_tab, current_main_tab_label, work
                         )
 
                     if cambios:
-                        if batch_update_gsheet_cells(worksheet, cambios, headers=headers):
+                        if batch_update_gsheet_cells(worksheet, cambios, headers=live_headers):
                             row_actualizado = dict(row)
                             row_actualizado["Fecha_Entrega"] = nueva_fecha_str
                             row_actualizado["Turno"] = nuevo_turno
 
-                            if "Fecha_Entrega" in headers:
+                            if "Fecha_Entrega" in live_headers:
                                 df.at[idx, "Fecha_Entrega"] = nueva_fecha_str
                             if (
-                                "Turno" in headers
+                                "Turno" in live_headers
                                 and tipo_envio_actual == "📍 Pedido Local"
                             ):
                                 df.at[idx, "Turno"] = nuevo_turno


### PR DESCRIPTION
### Motivation
- Corrige un fallo en el flujo “Cambiar Fecha y Turno” de pedidos locales donde, al aplicar, los índices de columna podían estar desalineados y escribir el valor de turno en la columna `Estado` o en otra columna incorrecta.
- Asegura que la "Nueva Fecha" realmente se guarde en `Fecha_Entrega` y que el cambio de `Turno` solo se intente cuando la columna correspondiente exista.

### Description
- Relee los encabezados reales de la hoja remota al momento de enviar el formulario y los guarda en `live_headers` para calcular índices de columna seguros con esos encabezados.
- Añade validaciones que muestran `st.error` y abortan la operación si faltan las columnas `Fecha_Entrega` o `Turno` en los encabezados leídos al enviar.
- Usa `live_headers` para todas las búsquedas de índices y para pasar la lista al call `batch_update_gsheet_cells`, y mantiene el blindaje de `Estado` basado en esos mismos encabezados.
- Actualiza el caché local (`df`) únicamente cuando las columnas modificadas están presentes en `live_headers` para evitar inconsistencias entre UI y Google Sheets.

### Testing
- Se compiló el módulo con `python -m py_compile app_a-d.py` y la comprobación pasó sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0f54f4dbc83268e07f966cd57d197)