### PR TITLE
Add alignment options to range formatting and uppercase normalization for Hoja_Ruta entries

### DIFF
--- a/app_a-d.py
+++ b/app_a-d.py
@@ -834,6 +834,8 @@ def _set_range_format(
     font_size: int,
     bold: bool,
     bg_color: Optional[dict[str, float]] = None,
+    horizontal_alignment: Optional[str] = None,
+    vertical_alignment: Optional[str] = None,
 ) -> None:
     """Aplica formato a un rango usando Spreadsheet.batch_update."""
     spreadsheet = getattr(ws, "spreadsheet", None)
@@ -852,6 +854,12 @@ def _set_range_format(
     if bg_color is not None:
         user_format["backgroundColor"] = bg_color
         fields += ",userEnteredFormat.backgroundColor"
+    if horizontal_alignment:
+        user_format["horizontalAlignment"] = str(horizontal_alignment).upper()
+        fields += ",userEnteredFormat.horizontalAlignment"
+    if vertical_alignment:
+        user_format["verticalAlignment"] = str(vertical_alignment).upper()
+        fields += ",userEnteredFormat.verticalAlignment"
 
     req = {
         "requests": [
@@ -912,6 +920,8 @@ def _format_hoja_ruta_data_row(ws: Any, row_number: int, n_value: int) -> None:
         font_size=28,
         bold=False,
         bg_color=row_bg,
+        horizontal_alignment="CENTER",
+        vertical_alignment="MIDDLE",
     )
 
 
@@ -932,15 +942,18 @@ def _append_local_dia_entry_to_hoja_ruta(row: Any, s3_client_param: Any, origen_
         return False
 
     extracted = _extract_hoja_ruta_fields_from_s3(s3_client_param, row)
+    def _upper_text(value: Any) -> str:
+        return _normalize_plain_text(value).upper()
+
     entry = {
-        "factura": _normalize_plain_text(row.get("Folio_Factura", "")),
-        "nombre_factura": _normalize_plain_text(row.get("Cliente", "")),
-        "municipio": _normalize_plain_text(extracted.get("municipio", "")),
-        "horario": _format_horario_corto(extracted.get("horario", "")),
-        "cantidad": _format_cantidad_sin_ceros(extracted.get("cantidad", "")),
-        "forma_pago": _normalize_plain_text(row.get("Estado_Pago", "")),
-        "vendedor": _recortar_vendedor_dos_nombres(row.get("Vendedor_Registro", "")),
-        "recibe": _normalize_plain_text(extracted.get("recibe", "")),
+        "factura": _upper_text(row.get("Folio_Factura", "")),
+        "nombre_factura": _upper_text(row.get("Cliente", "")),
+        "municipio": _upper_text(extracted.get("municipio", "")),
+        "horario": _upper_text(_format_horario_corto(extracted.get("horario", ""))),
+        "cantidad": _upper_text(_format_cantidad_sin_ceros(extracted.get("cantidad", ""))),
+        "forma_pago": _upper_text(row.get("Estado_Pago", "")),
+        "vendedor": _upper_text(_recortar_vendedor_dos_nombres(row.get("Vendedor_Registro", ""))),
+        "recibe": "",
         "firma": "",
     }
 


### PR DESCRIPTION
### Motivation
- Add explicit horizontal and vertical alignment support for range formatting to meet visual layout requirements.
- Ensure consistent uppercase formatting for fields written to Hoja_Ruta so entries are standardized.
- Clear out signature/receiver fields when appending local day entries to avoid carrying unexpected extracted values.

### Description
- Extend `_set_range_format` with optional `horizontal_alignment` and `vertical_alignment` parameters and include them in the `userEnteredFormat` payload when provided.
- Apply `horizontal_alignment="CENTER"` and `vertical_alignment="MIDDLE"` to data rows in `_format_hoja_ruta_data_row`.
- Introduce a local helper `_upper_text` in `_append_local_dia_entry_to_hoja_ruta` to normalize and uppercase text, and use it for `factura`, `nombre_factura`, `municipio`, `horario`, `cantidad`, `forma_pago`, and `vendedor` fields.
- Reset `recibe` and `firma` to empty strings when constructing the Hoja_Ruta entry to avoid retaining upstream values.

### Testing
- Ran the project's unit test suite with `pytest`, and all tests passed.
- Ran static checks with `flake8`, and no new linting errors were reported.
- Manual smoke validation of Google Sheets formatting changes confirmed `batch_update` requests include `horizontalAlignment` and `verticalAlignment` when specified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0f5a71e148326801e7b248822a42d)