### PR TITLE
Agregar extracción de WAYBILL desde PDFs y escribir número de guía en REPORTE GUÍAS (columna B)

### DIFF
--- a/app_a-d.py
+++ b/app_a-d.py
@@ -24,6 +24,7 @@ from pathlib import Path
 import requests
 import folium
 import polyline
+import pdfplumber
 
 _MX_TZ = timezone("America/Mexico_City")
 
@@ -178,30 +179,111 @@ def _obtener_siguiente_fila_reporte_guias(ws: Any) -> int:
     return fila_inicio
 
 
-def _escribir_reporte_guias_c_f(ws: Any, fila_destino: int, cliente_str: str, vendedor_recortado: str) -> None:
-    """Escribe C/F con compatibilidad entre versiones de gspread."""
+def _escribir_reporte_guias_b_c_f(
+    ws: Any,
+    fila_destino: int,
+    cliente_str: str,
+    vendedor_recortado: str,
+    numero_guia: str = "",
+) -> None:
+    """Escribe B/C/F con compatibilidad entre versiones de gspread."""
     _asegurar_filas_para_reporte_guias(ws, fila_destino)
 
-    payload = [
-        {"range": f"C{fila_destino}", "values": [[cliente_str]]},
-        {"range": f"F{fila_destino}", "values": [[vendedor_recortado]]},
-    ]
+    payload = [{"range": f"C{fila_destino}", "values": [[cliente_str]]}]
+    if numero_guia:
+        payload.append({"range": f"B{fila_destino}", "values": [[numero_guia]]})
+    payload.append({"range": f"F{fila_destino}", "values": [[vendedor_recortado]]})
 
     if hasattr(ws, "batch_update"):
         ws.batch_update(payload)
         return
 
     # Fallback para versiones antiguas sin batch_update en Worksheet.
+    b_col = gspread.utils.a1_to_rowcol(f"B{fila_destino}")[1]
     c_col = gspread.utils.a1_to_rowcol(f"C{fila_destino}")[1]
     f_col = gspread.utils.a1_to_rowcol(f"F{fila_destino}")[1]
     cells = [
-        gspread.Cell(row=fila_destino, col=c_col, value=cliente_str),
-        gspread.Cell(row=fila_destino, col=f_col, value=vendedor_recortado),
+        gspread.Cell(row=fila_destino, col=c_col, value=cliente_str)
     ]
+    if numero_guia:
+        cells.append(gspread.Cell(row=fila_destino, col=b_col, value=numero_guia))
+    cells.append(gspread.Cell(row=fila_destino, col=f_col, value=vendedor_recortado))
     ws.update_cells(cells)
 
 
-def escribir_en_reporte_guias(cliente: Any, vendedor: Any, tipo_envio: Any) -> bool:
+def _nombre_desde_url_o_key(value: Any) -> str:
+    val = str(value or "").strip()
+    if not val:
+        return ""
+    parsed = urlparse(val)
+    base = parsed.path if parsed.path else val
+    return os.path.basename(unquote(base)).strip()
+
+
+def _es_pdf_no_factura(file_name: str) -> bool:
+    normalized = _remove_accents(str(file_name or "")).lower()
+    if not normalized.endswith(".pdf"):
+        return False
+    return ("factura" not in normalized) and ("fact." not in normalized)
+
+
+def _seleccionar_pdf_guia(row: Any) -> Any:
+    adjuntos = _normalize_urls(row.get("Adjuntos", ""))
+    candidatos_adjuntos = []
+
+    for raw in adjuntos:
+        nombre = _nombre_desde_url_o_key(raw)
+        if not _es_pdf_no_factura(nombre):
+            continue
+        low = _remove_accents(nombre).lower()
+        if ("guia" in low) or ("descarga" in low):
+            candidatos_adjuntos.append(raw)
+
+    if candidatos_adjuntos:
+        return candidatos_adjuntos[0]
+
+    for key in ("Adjuntos_Guia", "Adjuntos_guia"):
+        guias = _normalize_urls(row.get(key, ""))
+        for raw in guias:
+            nombre = _nombre_desde_url_o_key(raw)
+            if str(nombre).lower().endswith(".pdf"):
+                return raw
+    return None
+
+
+def _extraer_waybill_desde_pdf_url(pdf_url: str) -> str:
+    if not pdf_url:
+        return ""
+    try:
+        response = requests.get(pdf_url, timeout=20)
+        response.raise_for_status()
+        with pdfplumber.open(BytesIO(response.content)) as pdf:
+            texto = "\n".join((p.extract_text() or "") for p in pdf.pages)
+        m = re.search(r"WAYBILL\s+(\d{2}\s\d{4}\s\d{4})", texto, flags=re.IGNORECASE)
+        if m:
+            return m.group(1).strip()
+    except Exception:
+        return ""
+    return ""
+
+
+def _obtener_numero_guia_desde_row(row: Any, s3_client_param: Any) -> str:
+    raw_pdf = _seleccionar_pdf_guia(row)
+    if not raw_pdf:
+        return ""
+    pdf_url = resolve_storage_url(s3_client_param, raw_pdf)
+    if not pdf_url:
+        return ""
+    return _extraer_waybill_desde_pdf_url(pdf_url)
+
+
+def escribir_en_reporte_guias(
+    cliente: Any,
+    vendedor: Any,
+    tipo_envio: Any,
+    row: Any = None,
+    s3_client_param: Any = None,
+) -> bool:
     tipo_envio_str = str(tipo_envio or "")
     if "Foráneo" not in tipo_envio_str:
         return True
@@ -222,12 +304,14 @@ def escribir_en_reporte_guias(cliente: Any, vendedor: Any, tipo_envio: Any) -> b
 
         vendedor_recortado = _recortar_vendedor_para_reporte(vendedor)
         cliente_str = str(cliente or "").strip()
+        numero_guia = _obtener_numero_guia_desde_row(row, s3_client_param) if row is not None else ""
 
-        _escribir_reporte_guias_c_f(
+        _escribir_reporte_guias_b_c_f(
             ws_reporte,
             fila_destino=fila_destino,
             cliente_str=cliente_str,
             vendedor_recortado=vendedor_recortado,
+            numero_guia=numero_guia,
         )
 
         return True
@@ -5153,6 +5237,8 @@ def mostrar_pedido_detalle(
                             cliente=row.get("Cliente", ""),
                             vendedor=row.get("Vendedor_Registro", ""),
                             tipo_envio=row.get("Tipo_Envio", ""),
+                            row=row,
+                            s3_client_param=s3_client_param,
                         )
                     elif _is_hoja_ruta_turno(origen_tab, row.get("Turno", "")):
                         _append_local_dia_entry_to_hoja_ruta(
@@ -6278,6 +6364,8 @@ def mostrar_pedido(df, idx, row, orden, origen_tab, current_main_tab_label, work
                                     cliente=row.get("Cliente", ""),
                                     vendedor=row.get("Vendedor_Registro", ""),
                                     tipo_envio=row.get("Tipo_Envio", ""),
+                                    row=row,
+                                    s3_client_param=s3_client_param,
                                 )
                             st.success("✅ Cambios de surtido confirmados y pedido en '🔵 En Proceso'.")
                             st.cache_data.clear()
@@ -6324,6 +6412,8 @@ def mostrar_pedido(df, idx, row, orden, origen_tab, current_main_tab_label, work
                                         cliente=row.get("Cliente", ""),
                                         vendedor=row.get("Vendedor_Registro", ""),
                                         tipo_envio=row.get("Tipo_Envio", ""),
+                                        row=row,
+                                        s3_client_param=s3_client_param,
                                     )
                                 st.success(
                                     "✅ Cambios de surtido confirmados y pedido en '🔵 En Proceso'."
@@ -8654,6 +8744,8 @@ if df_main is not None:
                                                     cliente=row.get("Cliente", ""),
                                                     vendedor=row.get("Vendedor_Registro", ""),
                                                     tipo_envio=row.get("Tipo_Envio", ""),
+                                                    row=row,
+                                                    s3_client_param=s3_client,
                                                 )
                                             st.success("✅ Cambios de surtido confirmados y pedido en '🔵 En Proceso'.")
                                             st.cache_data.clear()
@@ -9429,6 +9521,8 @@ if df_main is not None:
                                                     cliente=row.get("Cliente", ""),
                                                     vendedor=row.get("Vendedor_Registro", ""),
                                                     tipo_envio=row.get("Tipo_Envio", ""),
+                                                    row=row,
+                                                    s3_client_param=s3_client,
                                                 )
                                             st.success("✅ Cambios de surtido confirmados y pedido en '🔵 En Proceso'.")
                                             st.cache_data.clear()


### PR DESCRIPTION
### Motivation
- Añadir al flujo de procesamiento de pedidos foráneos la captura automática del número de guía (WAYBILL) desde PDFs y registrarlo en la columna B del `REPORTE GUÍAS` además de mantener cliente (C) y vendedor (F). 
- Seguir las reglas de negocio para seleccionar el PDF correcto: evitar archivos con `factura`/`fact.`, priorizar nombres con `guia`/`descarga`, y caer a `Adjuntos_Guia` / `Adjuntos_guia` si no hay candidatos en `Adjuntos`.

### Description
- Se incorporó `pdfplumber` y se implementaron nuevas utilidades: `_nombre_desde_url_o_key`, `_es_pdf_no_factura`, `_seleccionar_pdf_guia`, `_extraer_waybill_desde_pdf_url` y `_obtener_numero_guia_desde_row` para localizar y extraer el `WAYBILL` desde el PDF (patrón `WAYBILL XX XXXX XXXX`).
- Se reemplazó la función de escritura en hoja por `_escribir_reporte_guias_b_c_f` que escribe `B/C/F` y soporta tanto `batch_update` como el fallback con `update_cells`.
- Se amplió la firma de `escribir_en_reporte_guias` para aceptar `row` y `s3_client_param` y se actualizaron todos los callsites relevantes para proporcionar esos parámetros al invocar la escritura desde procesamiento/confirmación.
- La extracción de PDF baja el archivo con `requests`, intenta parsearlo con `pdfplumber` y es tolerante a errores (si falla, no interrumpe el flujo y solo se escribe C/F como antes).

### Testing
- Se ejecutó `python -m py_compile app_a-d.py` y la compilación del módulo fue exitosa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0f5d4d95c8326aba75f9d61869cd8)