### PR TITLE
Auto-extract waybill from attached PDFs and write guia to report sheet

### DIFF
--- a/app_a-d.py
+++ b/app_a-d.py
@@ -24,6 +24,7 @@ from pathlib import Path
 import requests
 import folium
 import polyline
+import pdfplumber
 
 _MX_TZ = timezone("America/Mexico_City")
 
@@ -201,7 +202,102 @@ def _escribir_reporte_guias_c_f(ws: Any, fila_destino: int, cliente_str: str, ve
     ws.update_cells(cells)
 
 
-def escribir_en_reporte_guias(cliente: Any, vendedor: Any, tipo_envio: Any) -> bool:
+def _escribir_reporte_guias_b(ws: Any, fila_destino: int, numero_guia: str) -> None:
+    numero_guia_str = str(numero_guia or "").strip()
+    if not numero_guia_str:
+        return
+    _asegurar_filas_para_reporte_guias(ws, fila_destino)
+
+    if hasattr(ws, "batch_update"):
+        ws.batch_update([{"range": f"B{fila_destino}", "values": [[numero_guia_str]]}])
+        return
+
+    b_col = gspread.utils.a1_to_rowcol(f"B{fila_destino}")[1]
+    cells = [gspread.Cell(row=fila_destino, col=b_col, value=numero_guia_str)]
+    ws.update_cells(cells)
+
+
+def _nombre_desde_url_o_key(value: Any) -> str:
+    val = str(value or "").strip()
+    if not val:
+        return ""
+    parsed = urlparse(val)
+    base = parsed.path if parsed.path else val
+    return os.path.basename(unquote(base)).strip()
+
+
+def _es_pdf_no_factura(file_name: str) -> bool:
+    normalized = _remove_accents(str(file_name or "")).lower()
+    if not normalized.endswith(".pdf"):
+        return False
+    return ("factura" not in normalized) and ("fact." not in normalized)
+
+
+def _seleccionar_pdf_guia(row: Any) -> Any:
+    adjuntos = _normalize_urls(row.get("Adjuntos", ""))
+    candidatos_adjuntos = []
+    candidatos_prioritarios = []
+
+    for raw in adjuntos:
+        nombre = _nombre_desde_url_o_key(raw)
+        if not _es_pdf_no_factura(nombre):
+            continue
+        candidatos_adjuntos.append(raw)
+        low = _remove_accents(nombre).lower()
+        if ("guia" in low) or ("descarga" in low):
+            candidatos_prioritarios.append(raw)
+
+    if candidatos_prioritarios:
+        return candidatos_prioritarios[0]
+    if candidatos_adjuntos:
+        return candidatos_adjuntos[0]
+
+    for key in ("Adjuntos_Guia", "Adjuntos_guia"):
+        guias = _normalize_urls(row.get(key, ""))
+        for raw in guias:
+            nombre = _nombre_desde_url_o_key(raw)
+            if str(nombre).lower().endswith(".pdf"):
+                return raw
+    return None
+
+
+def _extraer_waybill_desde_pdf_url(pdf_url: str) -> str:
+    if not pdf_url:
+        return ""
+    try:
+        response = requests.get(pdf_url, timeout=20)
+        response.raise_for_status()
+        with pdfplumber.open(BytesIO(response.content)) as pdf:
+            texto = "\n".join((p.extract_text() or "") for p in pdf.pages)
+        m = re.search(r"WAYBILL[^\d]*(\d[\d\s]{7,20}\d)", texto, flags=re.IGNORECASE)
+        if m:
+            solo_digitos = re.sub(r"\D", "", m.group(1))
+            if len(solo_digitos) >= 10:
+                solo_digitos = solo_digitos[:10]
+                return f"{solo_digitos[:2]} {solo_digitos[2:6]} {solo_digitos[6:10]}"
+            return m.group(1).strip()
+    except Exception:
+        return ""
+    return ""
+
+
+def _obtener_numero_guia_desde_row(row: Any, s3_client_param: Any) -> str:
+    raw_pdf = _seleccionar_pdf_guia(row)
+    if not raw_pdf:
+        return ""
+    pdf_url = resolve_storage_url(s3_client_param, raw_pdf)
+    if not pdf_url:
+        return ""
+    return _extraer_waybill_desde_pdf_url(pdf_url)
+
+
+def escribir_en_reporte_guias(
+    cliente: Any,
+    vendedor: Any,
+    tipo_envio: Any,
+    row: Any = None,
+    s3_client_param: Any = None,
+) -> bool:
     tipo_envio_str = str(tipo_envio or "")
     if "Foráneo" not in tipo_envio_str:
         return True
@@ -222,13 +318,14 @@ def escribir_en_reporte_guias(cliente: Any, vendedor: Any, tipo_envio: Any) -> b
 
         vendedor_recortado = _recortar_vendedor_para_reporte(vendedor)
         cliente_str = str(cliente or "").strip()
+        numero_guia = _obtener_numero_guia_desde_row(row, s3_client_param) if row is not None else ""
 
+        # Mantener exactamente el flujo original de C/F.
         _escribir_reporte_guias_c_f(
-            ws_reporte,
-            fila_destino=fila_destino,
-            cliente_str=cliente_str,
-            vendedor_recortado=vendedor_recortado,
+            ws_reporte, fila_destino=fila_destino, cliente_str=cliente_str, vendedor_recortado=vendedor_recortado
         )
+        # Escribir la guía en la columna inmediata a la izquierda del cliente (columna B).
+        _escribir_reporte_guias_b(ws_reporte, fila_destino=fila_destino, numero_guia=numero_guia)
 
         return True
     except Exception as e:
@@ -5153,6 +5250,8 @@ def mostrar_pedido_detalle(
                             cliente=row.get("Cliente", ""),
                             vendedor=row.get("Vendedor_Registro", ""),
                             tipo_envio=row.get("Tipo_Envio", ""),
+                            row=row,
+                            s3_client_param=s3_client_param,
                         )
                     elif _is_hoja_ruta_turno(origen_tab, row.get("Turno", "")):
                         _append_local_dia_entry_to_hoja_ruta(
@@ -6278,6 +6377,8 @@ def mostrar_pedido(df, idx, row, orden, origen_tab, current_main_tab_label, work
                                     cliente=row.get("Cliente", ""),
                                     vendedor=row.get("Vendedor_Registro", ""),
                                     tipo_envio=row.get("Tipo_Envio", ""),
+                                    row=row,
+                                    s3_client_param=s3_client_param,
                                 )
                             st.success("✅ Cambios de surtido confirmados y pedido en '🔵 En Proceso'.")
                             st.cache_data.clear()
@@ -6324,6 +6425,8 @@ def mostrar_pedido(df, idx, row, orden, origen_tab, current_main_tab_label, work
                                         cliente=row.get("Cliente", ""),
                                         vendedor=row.get("Vendedor_Registro", ""),
                                         tipo_envio=row.get("Tipo_Envio", ""),
+                                        row=row,
+                                        s3_client_param=s3_client_param,
                                     )
                                 st.success(
                                     "✅ Cambios de surtido confirmados y pedido en '🔵 En Proceso'."
@@ -8654,6 +8757,8 @@ if df_main is not None:
                                                     cliente=row.get("Cliente", ""),
                                                     vendedor=row.get("Vendedor_Registro", ""),
                                                     tipo_envio=row.get("Tipo_Envio", ""),
+                                                    row=row,
+                                                    s3_client_param=s3_client,
                                                 )
                                             st.success("✅ Cambios de surtido confirmados y pedido en '🔵 En Proceso'.")
                                             st.cache_data.clear()
@@ -9429,6 +9534,8 @@ if df_main is not None:
                                                     cliente=row.get("Cliente", ""),
                                                     vendedor=row.get("Vendedor_Registro", ""),
                                                     tipo_envio=row.get("Tipo_Envio", ""),
+                                                    row=row,
+                                                    s3_client_param=s3_client,
                                                 )
                                             st.success("✅ Cambios de surtido confirmados y pedido en '🔵 En Proceso'.")
                                             st.cache_data.clear()


### PR DESCRIPTION
### Motivation
- Automatically capture waybill/guide numbers from PDF attachments for "Foráneo" orders to avoid manual entry when marking orders as "En Proceso".
- Ignore invoice PDFs and prefer files whose names indicate guides or downloads.
- Preserve existing behavior of writing C/F columns while adding writing of the guide number to the sheet.

### Description
- Added `pdfplumber` import and new helpers: `_nombre_desde_url_o_key`, `_es_pdf_no_factura`, `_seleccionar_pdf_guia`, `_extraer_waybill_desde_pdf_url`, and `_obtener_numero_guia_desde_row` to locate and extract waybill numbers from PDFs (including fetching the PDF via `requests`).
- Introduced `_escribir_reporte_guias_b` to write the guide number into column B with `batch_update` and a cell-update fallback.
- Extended `escribir_en_reporte_guias` signature to accept `row` and `s3_client_param`, call the new extraction flow to resolve S3/storage URLs and write the extracted guide into the report sheet while preserving the existing C/F write via `_escribir_reporte_guias_c_f`.
- Updated call sites to pass `row` and `s3_client_param` when invoking `escribir_en_reporte_guias` so guides can be extracted when orders move to "🔵 En Proceso" or when surtido changes are confirmed.

### Testing
- Ran the project's automated test suite with `pytest` and linters; the test suite and lint checks passed.
- Performed a runtime smoke check in the development environment to validate that `escribir_en_reporte_guias` still writes C/F and also writes guide numbers when a suitable PDF is attached; the smoke check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0f5d4d95c8326aba75f9d61869cd8)