### PR TITLE
Open expanders instead of preserving tab context when marking comment 'Enterado'

### DIFF
--- a/app_a-d.py
+++ b/app_a-d.py
@@ -4633,11 +4633,10 @@ def _preserve_and_mark_skip_demorado() -> None:
 
 
 def _on_comentario_enterado_change(row_id: str, origen_tab: str) -> None:
-    """Preserva contexto visual al marcar/desmarcar Enterado en comentarios."""
+    """Mantiene la UX estable al marcar/desmarcar Enterado sin saltos de pestaña."""
 
     _mark_skip_demorado_check_once()
-    preserve_tab_state()
-    marcar_contexto_pedido(row_id, origen_tab, scroll=False)
+    ensure_expanders_open(row_id, "expanded_pedidos")
 
 
 def completar_pedido(


### PR DESCRIPTION
### Motivation
- Reduce UI jumps when toggling the "Enterado" flag by keeping relevant expanders open instead of performing a full tab/context preservation and re-focus.

### Description
- In `_on_comentario_enterado_change` replaced the calls to `preserve_tab_state()` and `marcar_contexto_pedido(row_id, origen_tab, scroll=False)` with a single call to `ensure_expanders_open(row_id, "expanded_pedidos")` and updated the docstring to reflect the UX intent.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f106b562188326a3605a8dc85dff3e)