### PR TITLE
Move 'Enterado' confirmation into Procesar flow and avoid checkbox-triggered reruns

### DIFF
--- a/app_a-d.py
+++ b/app_a-d.py
@@ -4632,14 +4632,6 @@ def _preserve_and_mark_skip_demorado() -> None:
     _mark_skip_demorado_check_once()
 
 
-def _on_comentario_enterado_change(row_id: str, origen_tab: str) -> None:
-    """Preserva contexto visual al marcar/desmarcar Enterado en comentarios."""
-
-    _mark_skip_demorado_check_once()
-    preserve_tab_state()
-    marcar_contexto_pedido(row_id, origen_tab, scroll=False)
-
-
 def completar_pedido(
     df: pd.DataFrame,
     idx: int,
@@ -5191,21 +5183,46 @@ def mostrar_pedido_detalle(
     gsheet_row_index,
     col_print_btn,
     s3_client_param,
-    comentario_enterado_ok=True,
+    comentario_requiere_confirmacion=False,
+    comentario_enterado_key: Optional[str] = None,
 ):
     """Procesa el pedido: actualiza estado a 'En Proceso' sin alterar UI."""
 
     estado_actual_ui = str(row.get("Estado", "")).strip()
     puede_procesar_ui = estado_actual_ui in ["🟡 Pendiente", "🔴 Demorado"]
 
-    boton_procesar_habilitado = puede_procesar_ui and comentario_enterado_ok
+    comentario_enterado_ok = True
+    clicked_procesar = False
+    if comentario_requiere_confirmacion:
+        form_key = f"form_procesar_con_enterado_{row['ID_Pedido']}_{origen_tab}"
+        with col_print_btn.form(form_key):
+            comentario_enterado_ok = st.checkbox(
+                "✅ Enterado",
+                key=f"enterado_form_{row['ID_Pedido']}_{origen_tab}",
+                help="Confirma que leíste el comentario antes de procesar.",
+            )
+            clicked_procesar = st.form_submit_button(
+                "⚙️ Procesar",
+                on_click=_mark_skip_demorado_check_once,
+                disabled=not puede_procesar_ui,
+                use_container_width=True,
+            )
+    else:
+        clicked_procesar = col_print_btn.button(
+            "⚙️ Procesar",
+            key=f"procesar_{row['ID_Pedido']}_{origen_tab}",
+            on_click=_mark_skip_demorado_check_once,
+            disabled=not puede_procesar_ui,
+        )
 
-    if col_print_btn.button(
-        "⚙️ Procesar",
-        key=f"procesar_{row['ID_Pedido']}_{origen_tab}",
-        on_click=_mark_skip_demorado_check_once,
-        disabled=not boton_procesar_habilitado,
-    ):
+    if clicked_procesar:
+        if comentario_requiere_confirmacion and comentario_enterado_key:
+            st.session_state[comentario_enterado_key] = comentario_enterado_ok
+
+        if not comentario_enterado_ok:
+            st.warning("⚠️ Debes marcar **Enterado** antes de procesar este pedido.")
+            return
+
         # Solo para marcar que ya se presionó (si se usa para estilos/toasts)
         st.session_state.setdefault("printed_items", {})
         st.session_state["printed_items"][row["ID_Pedido"]] = True
@@ -5359,11 +5376,9 @@ def mostrar_pedido(df, idx, row, orden, origen_tab, current_main_tab_label, work
     ) else ""
     comentario_resumen = str(row.get("Comentario", "")).strip()
     enterado_key = f"enterado_comentario_{row['ID_Pedido']}"
-    comentario_enterado_actual = bool(st.session_state.get(enterado_key, False))
-    comentario_marker = "💬 " if (comentario_resumen and not comentario_enterado_actual) else ""
     st.markdown(f'<a name="pedido_{row["ID_Pedido"]}"></a>', unsafe_allow_html=True)
     _render_bulk_selector(row)
-    titulo_expander = f"{guia_marker}{comentario_marker}{row['Estado']} - {folio} - {row['Cliente']}"
+    titulo_expander = f"{guia_marker}{row['Estado']} - {folio} - {row['Cliente']}"
     if es_local_bodega:
         titulo_expander = f"{titulo_expander} | Estado de pago: {pago_badge}"
 
@@ -5630,19 +5645,12 @@ def mostrar_pedido(df, idx, row, orden, origen_tab, current_main_tab_label, work
         col_order_num, col_client, col_time, col_status, col_vendedor, col_print_btn, col_complete_btn = st.columns([0.5, 2, 1.5, 1, 1.2, 1, 1])
         # --- Mostrar Comentario (si existe)
         comentario = comentario_resumen
-        comentario_enterado_ok = True
+        comentario_requiere_confirmacion = bool(comentario)
         if comentario:
             st.markdown("##### 💬 Comentario del Pedido")
             st.info(comentario)
-            comentario_enterado_ok = st.checkbox(
-                "✅ Enterado",
-                key=enterado_key,
-                help="Marca esta casilla para confirmar que leíste el comentario antes de procesar el pedido.",
-                on_change=_on_comentario_enterado_change,
-                args=(row["ID_Pedido"], origen_tab),
-            )
-            if not comentario_enterado_ok and row.get("Estado") in ["🟡 Pendiente", "🔴 Demorado"]:
-                st.caption("⚠️ Debes marcar **Enterado** para habilitar el botón **⚙️ Procesar**.")
+            if row.get("Estado") in ["🟡 Pendiente", "🔴 Demorado"]:
+                st.caption("✅ El check **Enterado** se confirma junto al botón **⚙️ Procesar** para evitar recargas al cambiarlo.")
 
         if es_local_no_entregado:
             estado_entrega_valor = str(row.get("Estado_Entrega", "")).strip()
@@ -5693,7 +5701,8 @@ def mostrar_pedido(df, idx, row, orden, origen_tab, current_main_tab_label, work
                 gsheet_row_index,
                 col_print_btn,
                 s3_client_param,
-                comentario_enterado_ok=comentario_enterado_ok,
+                comentario_requiere_confirmacion=comentario_requiere_confirmacion,
+                comentario_enterado_key=enterado_key,
             )
         else:
             col_print_btn.write("")


### PR DESCRIPTION
### Motivation
- Avoid unexpected reruns and UI state changes triggered by the global per-order `Enterado` checkbox while preserving the requirement to confirm reading a comment before processing an order.
- Simplify and centralize the processing action so the confirmation is performed together with the `Procesar` action to reduce visual state side-effects.

### Description
- Remove the `_on_comentario_enterado_change` handler and the global per-order `Enterado` checkbox that previously mutated `st.session_state` on change.
- Introduce parameters `comentario_requiere_confirmacion` and `comentario_enterado_key` on `mostrar_pedido_detalle` and handle confirmation inline by rendering a form with a checkbox `enterado_form_*` and a `form_submit_button` when a comment exists.
- Unify processing logic using a `clicked_procesar` path that sets `skip_demorado_check_once` on click and enforces that `Enterado` must be checked when required, showing a warning if not.
- Remove the inline comment marker from expander titles and update the caption to explain that `Enterado` is confirmed alongside the `⚙️ Procesar` button to prevent extra reruns.

### Testing
- Ran the automated test suite with `pytest` against the modified codebase and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f106b562188326a3605a8dc85dff3e)