### PR TITLE
Broaden base-phrase matching for organizer comments and remove "Material en tránsito" from base list

### DIFF
--- a/app_gerente.py
+++ b/app_gerente.py
@@ -8033,10 +8033,9 @@ if "organizador" in tab_map:
                     "Cliente devolvió material",
                     "Material reubicado en bodega",
                     "Diferencia pagada",
-                    "Material en tránsito",
                 ]
 
-                def _comentario_tiene_frase_base_exacta(comentario_val: str) -> bool:
+                def _comentario_inicia_con_frase_base(comentario_val: str) -> bool:
                     comentario_txt = str(comentario_val or "").strip()
                     if not comentario_txt:
                         return False
@@ -8044,6 +8043,8 @@ if "organizador" in tab_map:
                     for frase in frases_base_nuevo_sistema:
                         frase_norm = normalizar(frase)
                         if comentario_norm == frase_norm:
+                            return True
+                        if comentario_norm.startswith(f"{frase_norm} "):
                             return True
                     return False
 
@@ -8056,7 +8057,7 @@ if "organizador" in tab_map:
                 comentario_limpio = comentario_gerente_series.astype(str).str.strip()
                 mask_seguimiento_vacio = seguimiento_series.astype(str).str.strip() == ""
                 mask_comentario_vacio = comentario_limpio == ""
-                mask_comentario_base_exacto = comentario_gerente_series.apply(_comentario_tiene_frase_base_exacta)
+                mask_comentario_base_exacto = comentario_gerente_series.apply(_comentario_inicia_con_frase_base)
                 mask_comentario_libre = comentario_limpio.ne("") & ~mask_comentario_base_exacto
                 mask_mostrar_caso = mask_comentario_libre | (mask_comentario_vacio & mask_seguimiento_vacio)
                 df_casos_filtrado = df_casos_filtrado[


### PR DESCRIPTION
### Motivation
- Improve filtering for organizer cases so manager comments that begin with a known base phrase followed by extra text are treated as base comments and not classified as free-form.
- Adjust the set of base phrases by removing the phrase `"Material en tránsito"` from the base list.

### Description
- Removed `"Material en tránsito"` from the `frases_base_nuevo_sistema` list.
- Renamed helper to ` _comentario_inicia_con_frase_base` and changed its matching to return true when the normalized comment either equals a base phrase or `startswith` the normalized base phrase followed by a space.
- Replaced the previous mask computation to use the new helper so comments that begin with a base phrase plus additional text are now treated as base comments.

### Testing
- Ran the test suite with `pytest` against the repository and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f220aaa1c88326a910a1fc636544e6)