### PR TITLE
Treat comments that start with base phrases as base comments and remove 'Material en tránsito'

### DIFF
--- a/app_gerente.py
+++ b/app_gerente.py
@@ -8033,10 +8033,9 @@ if "organizador" in tab_map:
                     "Cliente devolvió material",
                     "Material reubicado en bodega",
                     "Diferencia pagada",
-                    "Material en tránsito",
                 ]
 
-                def _comentario_tiene_frase_base_exacta(comentario_val: str) -> bool:
+                def _comentario_inicia_con_frase_base(comentario_val: str) -> bool:
                     comentario_txt = str(comentario_val or "").strip()
                     if not comentario_txt:
                         return False
@@ -8045,6 +8044,10 @@ if "organizador" in tab_map:
                         frase_norm = normalizar(frase)
                         if comentario_norm == frase_norm:
                             return True
+                        if comentario_norm.startswith(frase_norm):
+                            resto = comentario_norm[len(frase_norm):]
+                            if not resto or not resto[0].isalnum():
+                                return True
                     return False
 
                 seguimiento_series = df_casos_filtrado.get(
@@ -8056,7 +8059,7 @@ if "organizador" in tab_map:
                 comentario_limpio = comentario_gerente_series.astype(str).str.strip()
                 mask_seguimiento_vacio = seguimiento_series.astype(str).str.strip() == ""
                 mask_comentario_vacio = comentario_limpio == ""
-                mask_comentario_base_exacto = comentario_gerente_series.apply(_comentario_tiene_frase_base_exacta)
+                mask_comentario_base_exacto = comentario_gerente_series.apply(_comentario_inicia_con_frase_base)
                 mask_comentario_libre = comentario_limpio.ne("") & ~mask_comentario_base_exacto
                 mask_mostrar_caso = mask_comentario_libre | (mask_comentario_vacio & mask_seguimiento_vacio)
                 df_casos_filtrado = df_casos_filtrado[


### PR DESCRIPTION
### Motivation
- Allow manager comments that begin with a known base phrase (optionally followed by punctuation or spacing) to be classified as base comments instead of requiring an exact match.

### Description
- Renamed ` _comentario_tiene_frase_base_exacta` to `_comentario_inicia_con_frase_base` and updated its logic to return true when a normalized comment equals a base phrase or starts with a base phrase that is followed only by a non-alphanumeric character or end-of-string, and removed `"Material en tránsito"` from `frases_base_nuevo_sistema`; the comment mask now uses the new function.

### Testing
- Ran the project test suite with `pytest` and linting; all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f220aaa1c88326a910a1fc636544e6)