### PR TITLE
Cache cobranza seguimiento data and improve client/folio selection UI

### DIFF
--- a/app_gerente.py
+++ b/app_gerente.py
@@ -3951,6 +3951,7 @@ def render_seguimiento_cobranza_tab_gerente(usuario_actual: str | None):
     with top_actions_col:
         if st.button("🔄 Recargar conexión", key="ger_seg_cob_top_retry"):
             reset_cobranza_connection_state()
+            st.session_state.pop("ger_seg_cob_data_cache", None)
             st.rerun()
 
     ws_base, _, ws_com = get_cobranza_worksheets_safe()
@@ -3983,23 +3984,33 @@ def render_seguimiento_cobranza_tab_gerente(usuario_actual: str | None):
             )
         return
 
-    try:
-        base_df = pd.DataFrame(cobranza_load_records_with_rows(ws_base))
-        com_df = pd.DataFrame(cobranza_load_records_with_rows(ws_com))
-    except gspread.exceptions.APIError as e:
-        _render_cobranza_retry_box(
-            "⚠️ No se pudieron leer los seguimientos desde Google Sheets en este momento.",
-            error=e,
-            key_suffix="load_seg_cob_data",
-        )
-        return
-    except Exception as e:
-        _render_cobranza_retry_box(
-            "⚠️ Ocurrió un problema al cargar el seguimiento de cobranza.",
-            error=e,
-            key_suffix="load_seg_cob_data_unexpected",
-        )
-        return
+    cache_payload = st.session_state.get("ger_seg_cob_data_cache")
+    if isinstance(cache_payload, dict) and {"base_df", "com_df"}.issubset(cache_payload.keys()):
+        base_df = cache_payload.get("base_df", pd.DataFrame()).copy()
+        com_df = cache_payload.get("com_df", pd.DataFrame()).copy()
+    else:
+        try:
+            base_df = pd.DataFrame(cobranza_load_records_with_rows(ws_base))
+            com_df = pd.DataFrame(cobranza_load_records_with_rows(ws_com))
+            st.session_state["ger_seg_cob_data_cache"] = {
+                "base_df": base_df.copy(),
+                "com_df": com_df.copy(),
+                "updated_at": now_cdmx().strftime("%Y-%m-%d %H:%M:%S"),
+            }
+        except gspread.exceptions.APIError as e:
+            _render_cobranza_retry_box(
+                "⚠️ No se pudieron leer los seguimientos desde Google Sheets en este momento.",
+                error=e,
+                key_suffix="load_seg_cob_data",
+            )
+            return
+        except Exception as e:
+            _render_cobranza_retry_box(
+                "⚠️ Ocurrió un problema al cargar el seguimiento de cobranza.",
+                error=e,
+                key_suffix="load_seg_cob_data_unexpected",
+            )
+            return
     if com_df.empty:
         st.info("Aún no hay seguimientos capturados.")
         return
@@ -4151,13 +4162,17 @@ def render_seguimiento_cobranza_tab_gerente(usuario_actual: str | None):
     seg_gestion["Codigo"] = seg_gestion.get("Codigo", "").astype(str)
     seg_gestion["Razon_Social"] = seg_gestion.get("Razon_Social", "").astype(str)
 
-    st.caption("Selecciona uno o varios folios por cliente para aplicar cambios masivos.")
-    row_sel_multi: list[int] = []
+    st.caption("Selecciona un cliente y luego uno o varios folios para aplicar cambios.")
+    clientes_ops = []
+    clientes_labels = {}
+    cliente_folios_map = {}
+
     for (codigo_cli, razon_cli), grp in seg_gestion.groupby(["Codigo", "Razon_Social"], sort=True):
         grp_sorted = grp.sort_values(["Fecha_Proximo_Pago", "Folio"]).copy()
         opciones_cli = []
         etiquetas_cli = {}
         fechas_vencimiento_cli = []
+
         for _, row in grp_sorted.iterrows():
             row_id = int(row.get("_row_id", 0) or 0)
             if row_id <= 0:
@@ -4168,32 +4183,54 @@ def render_seguimiento_cobranza_tab_gerente(usuario_actual: str | None):
                 fechas_vencimiento_cli.append(fecha_txt)
             folio_txt = _cobranza_clean_text(row.get("Folio", ""))
             estatus_txt = _cobranza_clean_text(row.get("Estatus_Seguimiento", "")).upper() or "PROMESA_PAGO"
-            comentario_txt = _cobranza_clean_text(row.get("Comentario", ""))
-            marca_estado = ""
-            if estatus_txt == "LIQUIDADO":
-                marca_estado = " 🟩 Liquidado"
+            marca_estado = " 🟩 Liquidado" if estatus_txt == "LIQUIDADO" else ""
             opciones_cli.append(row_id)
-            etiquetas_cli[row_id] = f"Folio {folio_txt}{marca_estado} · Estatus {estatus_txt} · Próximo pago {fecha_txt}"
+            etiquetas_cli[row_id] = f"Folio {folio_txt}{marca_estado} · Estatus {estatus_txt} · Próximo pago {fecha_txt or 'Sin fecha'}"
 
         if not opciones_cli:
             continue
 
+        cliente_key = f"{_cobranza_clean_text(codigo_cli)}|{_cobranza_clean_text(razon_cli)}"
         fechas_unicas = sorted(set(fechas_vencimiento_cli))
         fechas_label = ", ".join(fechas_unicas) if fechas_unicas else "Sin fecha"
-        exp_title = (
+        clientes_ops.append(cliente_key)
+        clientes_labels[cliente_key] = (
             f"{_cobranza_clean_text(codigo_cli)} · {_cobranza_clean_text(razon_cli)} "
             f"({len(opciones_cli)} folios) · Vence: {fechas_label}"
         )
-        with st.expander(exp_title, expanded=False):
-            sel_cli = st.multiselect(
-                "Folios en seguimiento",
-                options=opciones_cli,
-                format_func=lambda rid, map_et=etiquetas_cli: map_et.get(rid, str(rid)),
-                key=f"ger_seg_rows_cli_{_cobranza_clean_text(codigo_cli)}",
-            )
-            row_sel_multi.extend(int(rid) for rid in sel_cli)
+        cliente_folios_map[cliente_key] = {
+            "opciones": opciones_cli,
+            "labels": etiquetas_cli,
+        }
 
-    row_sel_multi = sorted(set(row_sel_multi))
+    if not clientes_ops:
+        st.info("No hay clientes con folios editables para esta vista.")
+        return
+
+    if len(clientes_ops) == 1:
+        cliente_sel = clientes_ops[0]
+        st.caption(f"Cliente: {clientes_labels.get(cliente_sel, cliente_sel)}")
+    else:
+        cliente_sel = st.selectbox(
+            "Cliente",
+            options=clientes_ops,
+            format_func=lambda k: clientes_labels.get(k, k),
+            key="ger_seg_cliente_selector",
+        )
+
+    cliente_payload = cliente_folios_map.get(cliente_sel, {"opciones": [], "labels": {}})
+    folios_opts = cliente_payload.get("opciones", [])
+    default_rows = folios_opts if len(folios_opts) == 1 else []
+    row_sel_multi = st.multiselect(
+        "Folios en seguimiento",
+        options=folios_opts,
+        default=default_rows,
+        format_func=lambda rid, map_et=cliente_payload.get("labels", {}): map_et.get(rid, str(rid)),
+        key="ger_seg_rows_multi",
+        help="Si el cliente solo tiene 1 folio, se selecciona automáticamente.",
+    )
+
+    row_sel_multi = sorted(set(int(rid) for rid in row_sel_multi))
     if not row_sel_multi:
         st.info("Selecciona al menos un folio para habilitar la edición de estatus, fecha y comentarios.")
         return
@@ -4264,6 +4301,7 @@ def render_seguimiento_cobranza_tab_gerente(usuario_actual: str | None):
 
         cobranza_update_row_values(ws_com, row_number, row_values)
 
+    st.session_state.pop("ger_seg_cob_data_cache", None)
     st.success(f"✅ Seguimiento actualizado en {len(row_sel_multi)} folio(s).")
     st.rerun()
 


### PR DESCRIPTION
### Motivation

- Reduce repeated Google Sheets reads when rendering the "Seguimiento Cobranza" view by caching loaded data in the Streamlit session state. 
- Improve UX for selecting folios by grouping by client and making client selection explicit when multiple clients exist. 
- Ensure cache is invalidated on manual reload and after updates so users see fresh data.

### Description

- Add `st.session_state` cache `ger_seg_cob_data_cache` to store `base_df`, `com_df`, and `updated_at`, and use it to avoid reloading sheets on every render. 
- Invalidate the cache on connection reload by popping `ger_seg_cob_data_cache` when the "Recargar conexión" button is pressed, and again after applying updates to follow-ups. 
- Replace per-client expander + global multiselect workflow with a two-step selection: a `selectbox` for client (when more than one) and a `multiselect` for that client's folios, with automatic selection when a client has a single folio. 
- Build and use `cliente_folios_map` and `clientes_labels` to provide friendly labels for client entries and folio formatting, including clearer "Sin fecha" labels and a compact "Liquidado" mark. 
- Normalize and coerce row ids to integers, sort selection, and keep prior protections for missing/invalid rows and API error handling.

### Testing

- Ran the project's automated test suite (existing CI/unit tests); all tests completed successfully. 
- Lint/static checks were executed as part of CI and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3757dc6cc8326a00cda43a782a4a5)