### PR TITLE
Evitar clientes duplicados en tabla "Clientes con saldo pendiente"

### DIFF
--- a/app_gerente.py
+++ b/app_gerente.py
@@ -3045,8 +3045,16 @@ def render_cobranza_tab_gerente():
                 else:
                     saldos_df = saldos_df.sort_values(["Fecha_Vencimiento_Min", "Saldo"], ascending=[True, False], na_position="last")
 
+                # La base histórica guarda un registro por cliente y mes.
+                # Si el filtro está en "Todos", consolidamos por cliente para evitar filas repetidas.
+                saldos_df["_mes_dt"] = pd.to_datetime(saldos_df.get("Mes", "") + "-01", errors="coerce")
+                saldos_df["_ult_act_dt"] = pd.to_datetime(saldos_df.get("Ultima_Actualizacion", ""), errors="coerce")
+                saldos_df = saldos_df.sort_values(["Codigo", "_mes_dt", "_ult_act_dt"], ascending=[True, False, False])
+                saldos_df = saldos_df.drop_duplicates(subset=["Codigo"], keep="first").copy()
+
                 saldos_df["Fecha_Vencimiento_Min"] = saldos_df["Fecha_Vencimiento_Min"].dt.strftime("%Y-%m-%d")
                 saldos_df["Fecha_Vencimiento_Max"] = saldos_df["Fecha_Vencimiento_Max"].dt.strftime("%Y-%m-%d")
+                saldos_df = saldos_df.drop(columns=[c for c in ["_mes_dt", "_ult_act_dt"] if c in saldos_df.columns])
                 cols_saldos = ["Mes", "Codigo", "Razon_Social", "Saldo", "Vencido", "No_Vencido", "Saldo_Vencido_Total", "Fecha_Vencimiento_Min", "Fecha_Vencimiento_Max", "Tipo_Pago", "Ultima_Actualizacion"]
                 cols_saldos = [c for c in cols_saldos if c in saldos_df.columns]
                 st.dataframe(saldos_df[cols_saldos], use_container_width=True, hide_index=True)


### PR DESCRIPTION
### Motivation
- La vista de saldos tomaba la `base_df` histórica que contiene un registro por `Mes`, lo que hacía que un mismo `Codigo` pudiera aparecer repetido con el mismo adeudo y distinto mes/fechas.
- Se busca mostrar un único registro por cliente en la lista de saldos pendientes para facilitar la revisión y evitar confusión por filas duplicadas.

### Description
- Se agregaron columnas auxiliares de fecha `"_mes_dt"` y `"_ult_act_dt"` construidas desde `Mes` y `Ultima_Actualizacion` para ordenar registros por recencia.
- Se ordena `saldos_df` por `"Codigo"`, `"_mes_dt"` y `"_ult_act_dt"` y se aplica `drop_duplicates(subset=["Codigo"], keep="first")` para consolidar un solo registro por cliente.
- Se eliminan las columnas auxiliares antes de renderizar y se mantiene la selección final de columnas mostradas en el `dataframe`.

### Testing
- Se verificó la sintaxis con `python -m py_compile app_gerente.py` y la compilación fue exitosa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3862e489c8326bce87d3aba457408)