### PR TITLE
Handle transient Google Sheets header read failures

### DIFF
--- a/app_i-d.py
+++ b/app_i-d.py
@@ -2956,7 +2956,11 @@ def _get_column_index_cached(sheet_name: str, column_name: str) -> Optional[int]
         return cached
 
     ws = _worksheet_by_name(sheet_name)
-    headers = ws.row_values(1)
+    try:
+        headers = ws.row_values(1)
+    except Exception:
+        # Evita que una falla transitoria de Google Sheets tumbe toda la app.
+        return cached if isinstance(cached, int) and cached > 0 else None
     if column_name not in headers:
         return None
 


### PR DESCRIPTION
### Motivation
- Evitar que fallas transitorias al leer la fila de encabezados de Google Sheets provoquen que la app de Streamlit muera con "Error running app" y requiera reinicio.

### Description
- En `app_i-d.py` se actualizó la función `_get_column_index_cached` para envolver la llamada a `ws.row_values(1)` en un `try/except` y devolver el índice en caché (si existe) o `None` en caso de un error transitorio, evitando propagar la excepción.

### Testing
- Se compiló el módulo con `python -m py_compile app_i-d.py` y se hizo el commit (`git commit`) exitosamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3868a6b4483269c623874b75de0e3)