### PR TITLE
Deduplicate historical monthly saldos only when code and balance/vencimiento match

### DIFF
--- a/app_gerente.py
+++ b/app_gerente.py
@@ -3038,6 +3038,17 @@ def render_cobranza_tab_gerente():
                 saldos_df["Fecha_Vencimiento_Min"] = pd.to_datetime(saldos_df.get("Fecha_Vencimiento_Min"), errors="coerce")
                 saldos_df["Fecha_Vencimiento_Max"] = pd.to_datetime(saldos_df.get("Fecha_Vencimiento_Max"), errors="coerce")
 
+                # La base histórica guarda un registro por cliente y mes.
+                # Para evitar ocultar clientes con movimientos distintos, solo colapsamos duplicados
+                # cuando tienen el mismo código y el mismo saldo/ventana de vencimiento.
+                saldos_df["_mes_dt"] = pd.to_datetime(saldos_df.get("Mes", "") + "-01", errors="coerce")
+                saldos_df["_ult_act_dt"] = pd.to_datetime(saldos_df.get("Ultima_Actualizacion", ""), errors="coerce")
+                saldos_df = saldos_df.sort_values(["Codigo", "_mes_dt", "_ult_act_dt"], ascending=[True, False, False])
+                saldos_df = saldos_df.drop_duplicates(
+                    subset=["Codigo", "Saldo_Vencido_Total", "Fecha_Vencimiento_Min", "Fecha_Vencimiento_Max"],
+                    keep="first",
+                ).copy()
+
                 if orden_sel == "Vencidas más caras a más baratas":
                     saldos_df = saldos_df.sort_values(["Vencido", "Saldo_Vencido_Total", "Saldo"], ascending=[False, False, False])
                 elif orden_sel == "Fecha de vencimiento más reciente a más antigua":
@@ -3047,6 +3058,7 @@ def render_cobranza_tab_gerente():
 
                 saldos_df["Fecha_Vencimiento_Min"] = saldos_df["Fecha_Vencimiento_Min"].dt.strftime("%Y-%m-%d")
                 saldos_df["Fecha_Vencimiento_Max"] = saldos_df["Fecha_Vencimiento_Max"].dt.strftime("%Y-%m-%d")
+                saldos_df = saldos_df.drop(columns=[c for c in ["_mes_dt", "_ult_act_dt"] if c in saldos_df.columns])
                 cols_saldos = ["Mes", "Codigo", "Razon_Social", "Saldo", "Vencido", "No_Vencido", "Saldo_Vencido_Total", "Fecha_Vencimiento_Min", "Fecha_Vencimiento_Max", "Tipo_Pago", "Ultima_Actualizacion"]
                 cols_saldos = [c for c in cols_saldos if c in saldos_df.columns]
                 st.dataframe(saldos_df[cols_saldos], use_container_width=True, hide_index=True)


### PR DESCRIPTION
### Motivation

- The historical saldos table stores one record per client and month and could produce duplicate rows that hide clients with distinct movements. 
- We need to collapse only truly duplicated entries and keep distinct movements for the same client and month.

### Description

- Add temporary columns `_mes_dt` and `_ult_act_dt` by parsing `Mes` and `Ultima_Actualizacion` into datetimes for ordering. 
- Sort `saldos_df` by `Codigo`, `_mes_dt` (most recent first), and `_ult_act_dt` (most recent first) and drop duplicates keeping the first row per `Codigo` where `Saldo_Vencido_Total`, `Fecha_Vencimiento_Min`, and `Fecha_Vencimiento_Max` are identical. 
- Remove the temporary `_mes_dt` and `_ult_act_dt` columns after deduplication and preserve the existing date formatting and column selection logic.

### Testing

- Ran the existing automated test suite with `pytest -q` and the tests completed successfully. 
- Performed a local smoke test of the `render_cobranza_tab_gerente` DataFrame rendering to verify deduplication behavior and date formatting, which behaved as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3862e489c8326bce87d3aba457408)