### PR TITLE
Restrict dashboard vendor list to configured credentials and update vendor mappings

### DIFF
--- a/app_i-d.py
+++ b/app_i-d.py
@@ -134,14 +134,14 @@ VENDEDOR_CREDENTIALS = {
     "CASSANDRA93": "CASSANDRA MIROSLAVA",
     "CECILIA94": "CECILIA SEPULVEDA",
     "DANIELA73": "DANIELA LOPEZ RAMIREZ",
-    "GRISELDA82": "GRISELDA CAROLINA SANCHEZ GARCIA",
+    "CARITO82": "GRISELDA CAROLINA SANCHEZ GARCIA",
     "GLORIA53": "GLORIA MICHELLE GARCIA TORRES",
     "JUAN24": "JUAN CASTILLEJO",
-    "JOSE31": "JOSE CORTES",
     "KAREN58": "KAREN JAQUELINE",
     "PAULINA57": "PAULINA TREJO",
-    "RUBEN67": "RUBEN",
     "ROBERTO51": "DISTRIBUCION Y UNIVERSIDADES",
+    "SANT1460": "SANTIAGO",
+    "SCHAVA": "SCHAVA",
     "SINAI": "SINAI",
 }
 
@@ -5137,7 +5137,18 @@ if selected_tab_key == "dashboard":
             if logged_vendor:
                 vendedores_raw = [logged_vendor]
 
-    _vendedores = sorted({sanitize_text(v) for v in vendedores_raw if sanitize_text(v)})
+    allowed_vendor_names = {
+        sanitize_text(nombre)
+        for user_key, nombre in VENDEDOR_CREDENTIALS.items()
+        if sanitize_text(nombre) and not is_non_vendor_user(user_key)
+    }
+    _vendedores = sorted(
+        {
+            sanitize_text(v)
+            for v in vendedores_raw
+            if sanitize_text(v) and sanitize_text(v) in allowed_vendor_names
+        }
+    )
 
     total_ventas = float(get_numeric_column(df_conf, "Monto_Comprobante", default=0.0).sum())
     total_pedidos = int(len(df_conf))


### PR DESCRIPTION
### Motivation

- Ensure the dashboard `Vendedor` dropdown only shows vendors that are in the configured `VENDEDOR_CREDENTIALS` and are not marked as non-vendor users. 
- Correct and update vendor credential keys to reflect current vendor identifiers and add missing vendors.

### Description

- Updated `VENDEDOR_CREDENTIALS` by replacing the key `GRISELDA82` with `CARITO82`, removing `JOSE31` and `RUBEN67`, and adding `SANT1460` and `SCHAVA` entries. 
- Added `allowed_vendor_names` derived from `VENDEDOR_CREDENTIALS` (excluding `NON_VENDOR_USERS`) and changed `_vendedores` to filter `vendedores_raw` against that set so only authorized vendor names appear. 
- Kept `is_non_vendor_user` and `resolve_vendor_for_user` behavior but used `is_non_vendor_user` when building the allowed names to avoid exposing non-vendor users in vendor lists.

### Testing

- Ran the project's unit test suite and linting locally and all tests passed. 
- Performed a local Streamlit smoke test to open the dashboard and verified the `Vendedor` dropdown shows only names present in `VENDEDOR_CREDENTIALS` and excludes `NON_VENDOR_USERS`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f39fe6d7a4832691721d66fc33f867)