### PR TITLE
Fix hoja de ruta date parsing for ISO delivery dates

### DIFF
--- a/app_a-d.py
+++ b/app_a-d.py
@@ -534,7 +534,16 @@ def _build_section_header(origen_tab: Any, row: Any, fecha_entrega: datetime.dat
 
 
 def _parse_fecha_entrega_local(fecha_raw: Any) -> Optional[datetime.date]:
-    fecha = pd.to_datetime(fecha_raw, errors="coerce", dayfirst=True)
+    raw = str(fecha_raw or "").strip()
+    if not raw:
+        return None
+
+    # Si llega en formato ISO (YYYY-MM-DD), no usar dayfirst=True porque
+    # fechas como 2026-05-04 podrían interpretarse como 2026-04-05.
+    if re.fullmatch(r"\d{4}-\d{2}-\d{2}", raw):
+        fecha = pd.to_datetime(raw, errors="coerce", format="%Y-%m-%d")
+    else:
+        fecha = pd.to_datetime(raw, errors="coerce", dayfirst=True)
     if pd.isna(fecha):
         return None
     return fecha.date()


### PR DESCRIPTION
### Motivation
- The local delivery date parser used `dayfirst=True` for all inputs which caused ISO dates like `2026-05-04` to be misinterpreted as `2026-04-05` and produced incorrect hoja de ruta section titles.
- The change prevents wrong day/month swaps when orders arrive with ISO `YYYY-MM-DD` dates so section headers match the intended delivery day.

### Description
- Update `_parse_fecha_entrega_local` to normalize the input with `raw = str(fecha_raw or "").strip()` and return `None` for empty values.
- Detect ISO date strings with `re.fullmatch(r"\d{4}-\d{2}-\d{2}", raw)` and parse them using `pd.to_datetime(raw, errors="coerce", format="%Y-%m-%d")`.
- Preserve existing behavior for non-ISO inputs by keeping `pd.to_datetime(..., dayfirst=True)` for other formats.

### Testing
- Ran `python -m py_compile /workspace/app_almacen_TD/app_a-d.py` and the file compiled successfully (no syntax errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3be2f7cf48326a4e4b5696b76dd1f)